### PR TITLE
Correct config path in getting started guide

### DIFF
--- a/typesense.org/docs/0.14.0/guide.html
+++ b/typesense.org/docs/0.14.0/guide.html
@@ -50,7 +50,7 @@ nav_label: guide
 
     <p>By default, Typesense will start on port <code>8108</code>, and the installation will generate a
        random API key, which you can view/change from the configuration file at
-      <code>/etc/typesense/typesense.ini</code></p>
+      <code>/etc/typesense/typesense-server.ini</code></p>
 
     <h4>From the pre-built binary</h4>
 


### PR DESCRIPTION
When I installed Typesense via the DEB, the config was at `/etc/typesense/typesense-server.ini` as opposed to `/etc/typesense/typesense.ini`. This is also what it says further down in the guide.

I only tested 0.14, so not sure if this also applies to the older versions.