### PR TITLE
Add missing permalink for docs/0.17.0

### DIFF
--- a/typesense.org/_config.yml
+++ b/typesense.org/_config.yml
@@ -99,6 +99,10 @@ defaults:
       path: "docs/0.16.1"
     values:
         permalink: "/docs/0.16.1/:basename/"
+  - scope:
+      path: "docs/0.17.0"
+    values:
+        permalink: "/docs/0.17.0/:basename/"
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
## Change Summary

First of all, thank you for version 0.17.0!

Did you know that https://typesense.org/docs/0.17.0/guide is 404-ing? https://typesense.org/docs/0.17.0/guide.html, however, is not.

I couldn't replicate this in the local development environment, but I did notice the `permalink` configuration from `_config.yml` was missing for this version. I have added that in this PR. Is it being used to generate redirects?

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
