### PR TITLE
Update search response

### DIFF
--- a/typesense.org/docs/0.18.0/api.html
+++ b/typesense.org/docs/0.18.0/api.html
@@ -565,7 +565,10 @@ nav_label: api
         {
           "facet_counts": [],
           "found": 1,
-          "took_ms": 1,
+          "out_of": 1,
+          "page": 1,
+          "request_params": { "q" : "" },
+          "search_time_ms": 1,
           "hits": [
             {
               "highlights": [
@@ -703,7 +706,10 @@ nav_label: api
       {
         "facet_counts": [],
         "found": 1,
-        "took_ms": 1,
+        "out_of": 1,
+        "page": 1,
+        "request_params": { "q" : "" },
+        "search_time_ms": 1,
         "grouped_hits": [
           {
             "group_key": ["USA"],


### PR DESCRIPTION
## Change Summary

The search response in v0.18 differs from what's mentioned in the docs. This PR updates the docs to reflect the current API response.

close https://github.com/typesense/typesense/issues/194

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
