### PR TITLE
Update api reference to include id restrictions

### DIFF
--- a/typesense.org/docs/0.18.0/api.html
+++ b/typesense.org/docs/0.18.0/api.html
@@ -355,7 +355,8 @@ nav_label: api
       <p>
         If the document contains an <code>id</code> field of type <code>string</code>, Typesense would use that
         field as the identifier for the document. Otherwise, Typesense would assign an identifier of its choice to
-        the document.
+        the document. Note that the <code>id</code> should not include spaces or any other characters that require
+        <a href='https://www.w3schools.com/tags/ref_urlencode.asp'>encoding in urls</a>.
       </p>
 
       {% code_block index-document %}


### PR DESCRIPTION
## Change Summary

Add a mention that a document `id` cannot include spaces or any other characters that are encoded in URLs, as using those characters in an `id` can cause issues.

close https://github.com/typesense/typesense/issues/192

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

Note: I've previously signed the CLA. I assume that's enough and I don't need to submit it again, but if required, I will.