### PR TITLE
Fix JS Client authentication typo -- missing comma

### DIFF
--- a/typesense.org/docs/0.18.0/api.html
+++ b/typesense.org/docs/0.18.0/api.html
@@ -63,7 +63,7 @@ nav_label: api
             'protocol': 'http',
           }],
 
-          'apiKey': '<API_KEY>'
+          'apiKey': '<API_KEY>',
           'connectionTimeoutSeconds': 2
         })
       ```


### PR DESCRIPTION
## Change Summary

There was a comma missing after `'apiKey': '<API_KEY>'`. See below.

```js
let client = new Typesense.Client({
  'nodes': [{
    'host': 'localhost',
    'port': '8108',
    'protocol': 'http',
  }],

  'apiKey': '<API_KEY>'
  'connectionTimeoutSeconds': 2
})
```

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

close https://github.com/typesense/typesense/issues/211