### PR TITLE
chore(instantsearch): clarify ownership

### DIFF
--- a/docs-site/content/0.13.0/guide/typesense-firebase.md
+++ b/docs-site/content/0.13.0/guide/typesense-firebase.md
@@ -147,7 +147,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 

--- a/docs-site/content/0.16.0/guide/firebase-full-text-search.md
+++ b/docs-site/content/0.16.0/guide/firebase-full-text-search.md
@@ -144,7 +144,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 

--- a/docs-site/content/0.16.1/guide/firebase-full-text-search.md
+++ b/docs-site/content/0.16.1/guide/firebase-full-text-search.md
@@ -144,7 +144,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 

--- a/docs-site/content/0.17.0/guide/firebase-full-text-search.md
+++ b/docs-site/content/0.17.0/guide/firebase-full-text-search.md
@@ -144,7 +144,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 

--- a/docs-site/content/0.18.0/guide/firebase-full-text-search.md
+++ b/docs-site/content/0.18.0/guide/firebase-full-text-search.md
@@ -144,7 +144,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 

--- a/docs-site/content/0.19.0/guide/firebase-full-text-search.md
+++ b/docs-site/content/0.19.0/guide/firebase-full-text-search.md
@@ -144,7 +144,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 

--- a/docs-site/content/0.20.0/guide/firebase-full-text-search.md
+++ b/docs-site/content/0.20.0/guide/firebase-full-text-search.md
@@ -144,7 +144,7 @@ Typesense is a typo-tolerant search engine. So, even if you make a typographical
 
 ### Build a Search UI
 
-You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built originally by Algolia.
+You can now add a search bar using [instantsearch.js](https://github.com/algolia/instantsearch.js), an open-sourced collection of UI components, built by Algolia.
 
 Typesense has an [instantsearch adapter](https://github.com/typesense/typesense-instantsearch-adapter) that you can use to create UI-based search interfaces, but send the queries to Typesense. 
 


### PR DESCRIPTION

## Change Summary

Removes "originally" in the description of instantsearch.

While according to the license, it's completely fine to refer to instantsearch as "made by algolia" and using an adapter for typesense, mentioning it's "originally" made by Algolia, while there's no modifications done by Typesense is slightly confusing IMO.

note: i'm not making this PR from the POV of Algolia legal, just as one of the developers on the project.
