### PR TITLE
docs: fix search-only api key description for js

### DIFF
--- a/docs-site/content/0.20.0/api/api-keys.md
+++ b/docs-site/content/0.20.0/api/api-keys.md
@@ -87,7 +87,7 @@ Let's now see how we can create a search-only key that allows you to limit the k
 
 ```js
 client.keys().create({
-  'description': 'Admin key.',
+  'description': 'Search-only companies key.',
   'actions': ['documents:search'],
   'collections': ['companies']
 })


### PR DESCRIPTION
## Change Summary

Looks like it was already fixed for the other languages, but the copied text from the section above remained for javascript.

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
