### PR TITLE
Publish Dart Examples

### DIFF
--- a/docs-site/content/0.20.0/api/api-keys.md
+++ b/docs-site/content/0.20.0/api/api-keys.md
@@ -16,7 +16,7 @@ We will be using the initial bootstrap key that you started Typesense with (via 
 
 Let's begin by creating an API key that allows you to do all operations, i.e. it's effectively an admin key and is equivalent to the key that you start Typesense with (via `--api-key`).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -99,7 +99,7 @@ The generated key is only returned during creation. You want to store this key c
 
 Let's now see how we can create a search-only key that allows you to limit the key's scope to only the search action, and also for only a specific collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -220,7 +220,7 @@ By setting the `actions` scope to `["documents:search"]` and the `collections` s
 ## Retrieve an API Key
 Retrieve (metadata about) a key.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -295,7 +295,7 @@ Notice how only the key prefix is returned when you retrieve a key. Due to secur
 ## List all Keys
 Retrieve (metadata about) all keys.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -388,7 +388,7 @@ Notice how only the key prefix is returned when you retrieve a key. Due to secur
 ## Delete API Key
 Delete an API key given its ID.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -495,7 +495,7 @@ Once a parent Search API Key is revoked, all scoped API keys that were generated
 
 We can generate scoped search API keys without having to make any calls to the Typesense server. We use an API key that we previously generated with a search scope (only), create an HMAC digest of the parameters with this key and use that as the API key. Our client libraries handle this logic for you, but you can also generate scoped search API keys from the command line.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.20.0/api/authentication.md
+++ b/docs-site/content/0.20.0/api/authentication.md
@@ -10,7 +10,7 @@ You'd need one or more hostnames and [API keys](./api-keys.md) to integrate with
 If you're self-hosting Typesense, the hostnames are the IP addresses or DNS names of each of your Typesense nodes. 
 If you're using Typesense Cloud, we generate unique hostnames for each of your nodes and show them on the dashboard for you to use. 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -91,6 +91,27 @@ client = Typesense::Client.new(
 ```
 
   </template>
+  <template v-slot:Dart>
+
+```dart
+import 'dart:io';
+import 'package:typesense/typesense.dart';
+
+final host = InternetAddress.loopbackIPv4.address;
+final config = Configuration(
+    nodes: {
+      Node(
+        host: host,        // For Typesense Cloud use xxx.a1.typesense.net
+        port: 8108,        // For Typesense Cloud use 443
+        protocol: 'http',  // For Typesense Cloud use https
+      ),
+    },
+    apiKey: '<API_KEY>',
+    connectionTimeout: Duration(seconds: 2),
+  );
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -111,7 +132,7 @@ On Typesense Cloud, you can turn ON a setting called `Search Delivery Network` a
 You'll be a given a special hostname called the Nearest Node hostname when you turn this setting on for your cluster. You'd then need to configure your clients to use this hostname:
 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -191,6 +212,42 @@ client = Typesense::Client.new(
   api_key:  '<API_KEY>',
   connection_timeout_seconds: 2
 )
+```
+
+  </template>
+  <template v-slot:Dart>
+
+```dart
+import 'package:typesense/typesense.dart';
+
+final config = Configuration(
+    // This is the special Nearest Node hostname that you'll see in the
+    // Typesense Cloud dashboard if you turn on Search Delivery Network.
+    nearestNode: Node(
+      host: 'xxx.a1.typesense.net',
+      port: 443,
+      protocol: 'https',
+    ),
+    nodes: {
+      Node(
+        host: 'xxx-1.a1.typesense.net',
+        port: 443,
+        protocol: 'https',
+      ),
+      Node(
+        host: 'xxx-2.a1.typesense.net',
+        port: 443,
+        protocol: 'https',
+      ),
+      Node(
+        host: 'xxx-3.a1.typesense.net',
+        port: 443,
+        protocol: 'https',
+      ),
+    },
+    apiKey: '<API_KEY>',
+    connectionTimeout: Duration(seconds: 2),
+  );
 ```
 
   </template>

--- a/docs-site/content/0.20.0/api/cluster-operations.md
+++ b/docs-site/content/0.20.0/api/cluster-operations.md
@@ -10,7 +10,7 @@ Creates a point-in-time snapshot of a Typesense node's state and data in the spe
 
 You can then backup the snapshot directory that gets created and later restore it as a data directory, as needed.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -85,7 +85,7 @@ Triggers a follower node to initiate the raft voting process, which triggers lea
 
 The follower node that you run this operation against will become the new leader, once this command succeeds.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -157,7 +157,7 @@ Default: `-1` which disables slow request logging.
 
 Slow requests are logged to the primary log file, with the prefix `SLOW REQUEST`.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -199,7 +199,7 @@ curl "http://localhost:8108/config" \
 
 Get current RAM, CPU, Disk & Network usage metrics.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -256,7 +256,7 @@ Get stats about API endpoints.
 
 This endpoint returns average requests per second and latencies for all requests in the last 10 seconds.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -303,7 +303,7 @@ curl "http://localhost:8108/stats.json" \
 
 Get health information about a Typesense node.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart

--- a/docs-site/content/0.20.0/api/collection-alias.md
+++ b/docs-site/content/0.20.0/api/collection-alias.md
@@ -20,7 +20,7 @@ Convenient isn't it? Let's now look at how we can create, update and manage alia
 
 ## Create or Update an alias
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -121,7 +121,7 @@ curl "http://localhost:8108/aliases/companies" -X PUT \
 ## Retrieve an alias
 We can find out which collection an alias points to by fetching it.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -190,7 +190,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## List all aliases
 List all aliases and the corresponding collections that they map to.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -265,7 +265,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 
 ## Delete an alias
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.20.0/api/collections.md
+++ b/docs-site/content/0.20.0/api/collections.md
@@ -22,7 +22,7 @@ Your documents can contain other fields not mentioned in the collection's schema
 on _disk_ but not indexed in _memory_.
 :::
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -331,7 +331,7 @@ You can control this default coercion behavior at write-time with the [`dirty_va
 ## Retrieve a collection
 Retrieve the details of a collection, given its name.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -407,7 +407,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## List all collections
 Returns a summary of all your collections. The collections are returned sorted by creation date, with the most recent collections appearing first.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -494,7 +494,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Drop a collection
 Permanently drops a collection. This action cannot be undone. For large collections, this might have an impact on read latencies.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.20.0/api/curation.md
+++ b/docs-site/content/0.20.0/api/curation.md
@@ -13,7 +13,7 @@ In the following example, we are overriding the search results by placing the do
 
 Note how we are applying these overrides to an `exact` match of the query `apple`. Instead, if we want to match all queries that contained the word `apple`, we will use the `contains` match instead.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -192,7 +192,7 @@ curl "http://localhost:8108/collections/companies/overrides/customize-apple" -X 
 ## List all overrides
 Listing all overrides associated with a given collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -283,7 +283,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Retrieve an override
 Fetch an individual override associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -370,7 +370,7 @@ curl "http://localhost:8108/collections/companies/overrides/customize-apple" -X 
 ## Delete an override
 Deleting an override associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.20.0/api/documents.md
+++ b/docs-site/content/0.20.0/api/documents.md
@@ -11,7 +11,7 @@ A document to be indexed in a given collection must conform to the schema of the
 
 If the document contains an `id` field of type `string`, Typesense would use that field as the identifier for the document. Otherwise, Typesense would assign an identifier of its choice to the document. Note that the id should not include spaces or any other characters that require [encoding in urls](https://www.w3schools.com/tags/ref_urlencode.asp).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby',  'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -104,7 +104,7 @@ curl "http://localhost:8108/collections/companies/documents" -X POST \
 You can also upsert a document.
 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby',  'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -219,7 +219,7 @@ To index multiple documents at the same time, in a batch/bulk operation, see [im
 ## Search
 In Typesense, a search consists of a query against one or more text fields and a list of filters against numerical or facet fields. You can also sort and facet your results.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -387,7 +387,7 @@ To group on a particular field, it must be a faceted field.
 
 Grouping returns the hits in a nested structure, that's different from the plain JSON response format we saw earlier. Let's repeat the query we made earlier with a `group_by` parameter:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -570,7 +570,7 @@ You can send multiple search requests in a single HTTP request, using the Multi-
 
 You can also use this feature to do a **federated search** across multiple collections in a single HTTP request.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -821,7 +821,7 @@ The `results` array in a `multi_search` response is guaranteed to be in the same
 ## Retrieve a document
 Fetch an individual document from a collection by using its id.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -892,7 +892,7 @@ $ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X GET \
 ## Update a document
 Update an individual document from a collection by using its id. The update can be partial, as shown below:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -991,7 +991,7 @@ curl "http://localhost:8108/collections/companies/documents/124" -X PATCH \
 ## Delete documents
 Delete an individual document from a collection by using its id.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1062,7 +1062,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X DELETE \
 
 You can also delete a bunch of documents that match a specific filter condition:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1133,7 +1133,7 @@ Use the `batch_size` parameter to control the number of documents that should de
 
 ## Export documents
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1216,7 +1216,7 @@ This is essentially one JSON object per line, without commas between documents. 
 
 If you are using one of our client libraries, you can also pass in an array of documents and the library will take care of converting it into JSONL.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1341,7 +1341,7 @@ Here's an example file:
 
 You can import the above `documents.jsonl` file like this.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1422,7 +1422,7 @@ Once you have the JSONL file, you can then import it following the [instructions
 
 By default, Typesense ingests 40 documents at a time into Typesense. To increase this value, use the `batch_size` parameter.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1528,7 +1528,7 @@ the default behavior is `reject` (this ensures backward compatibility with older
 Let's now attempt to index a document with a `title` field that contains an integer. We will assume that this
 field was previously inferred to be of type `string`. Let's use the `coerce_or_reject` behavior here:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.20.0/api/synonyms.md
+++ b/docs-site/content/0.20.0/api/synonyms.md
@@ -16,7 +16,7 @@ Typesense supports two types of synonyms:
 
 ### Multi-way synonym
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -108,7 +108,7 @@ curl "http://localhost:8108/collections/products/synonyms/coat-synonyms" -X PUT 
 
 ### One-way synonym
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -217,7 +217,7 @@ curl "http://localhost:8108/collections/products/synonyms/smart-phone-synonyms" 
 ## Retrieve a synonym
 We can retrieve a single synonym.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -285,7 +285,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/colle
 ## List all synonyms
 List all synonyms associated with a given collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -358,7 +358,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Delete a synonym
 Delete a synonym associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.21.0/api/api-keys.md
+++ b/docs-site/content/0.21.0/api/api-keys.md
@@ -16,7 +16,7 @@ We will be using the initial bootstrap key that you started Typesense with (via 
 
 Let's begin by creating an API key that allows you to do all operations, i.e. it's effectively an admin key and is equivalent to the key that you start Typesense with (via `--api-key`).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -99,7 +99,7 @@ The generated key is only returned during creation. You want to store this key c
 
 Let's now see how we can create a search-only key that allows you to limit the key's scope to only the search action, and also for only a specific collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -220,7 +220,7 @@ By setting the `actions` scope to `["documents:search"]` and the `collections` s
 ## Retrieve an API Key
 Retrieve (metadata about) a key.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -295,7 +295,7 @@ Notice how only the key prefix is returned when you retrieve a key. Due to secur
 ## List all Keys
 Retrieve (metadata about) all keys.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -388,7 +388,7 @@ Notice how only the key prefix is returned when you retrieve a key. Due to secur
 ## Delete API Key
 Delete an API key given its ID.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -495,7 +495,7 @@ Once a parent Search API Key is revoked, all scoped API keys that were generated
 
 We can generate scoped search API keys without having to make any calls to the Typesense server. We use an API key that we previously generated with a search scope (only), create an HMAC digest of the parameters with this key and use that as the API key. Our client libraries handle this logic for you, but you can also generate scoped search API keys from the command line.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.21.0/api/authentication.md
+++ b/docs-site/content/0.21.0/api/authentication.md
@@ -10,7 +10,7 @@ You'd need one or more hostnames and [API keys](./api-keys.md) to integrate with
 If you're self-hosting Typesense, the hostnames are the IP addresses or DNS names of each of your Typesense nodes. 
 If you're using Typesense Cloud, we generate unique hostnames for each of your nodes and show them on the dashboard for you to use. 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -91,6 +91,27 @@ client = Typesense::Client.new(
 ```
 
   </template>
+  <template v-slot:Dart>
+
+```dart
+import 'dart:io';
+import 'package:typesense/typesense.dart';
+
+final host = InternetAddress.loopbackIPv4.address;
+final config = Configuration(
+    nodes: {
+      Node(
+        host: host,        // For Typesense Cloud use xxx.a1.typesense.net
+        port: 8108,        // For Typesense Cloud use 443
+        protocol: 'http',  // For Typesense Cloud use https
+      ),
+    },
+    apiKey: '<API_KEY>',
+    connectionTimeout: Duration(seconds: 2),
+  );
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -111,7 +132,7 @@ On Typesense Cloud, you can turn ON a setting called `Search Delivery Network` a
 You'll be a given a special hostname called the Nearest Node hostname when you turn this setting on for your cluster. You'd then need to configure your clients to use this hostname:
 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -191,6 +212,42 @@ client = Typesense::Client.new(
   api_key:  '<API_KEY>',
   connection_timeout_seconds: 2
 )
+```
+
+  </template>
+  <template v-slot:Dart>
+
+```dart
+import 'package:typesense/typesense.dart';
+
+final config = Configuration(
+    // This is the special Nearest Node hostname that you'll see in the
+    // Typesense Cloud dashboard if you turn on Search Delivery Network.
+    nearestNode: Node(
+      host: 'xxx.a1.typesense.net',
+      port: 443,
+      protocol: 'https',
+    ),
+    nodes: {
+      Node(
+        host: 'xxx-1.a1.typesense.net',
+        port: 443,
+        protocol: 'https',
+      ),
+      Node(
+        host: 'xxx-2.a1.typesense.net',
+        port: 443,
+        protocol: 'https',
+      ),
+      Node(
+        host: 'xxx-3.a1.typesense.net',
+        port: 443,
+        protocol: 'https',
+      ),
+    },
+    apiKey: '<API_KEY>',
+    connectionTimeout: Duration(seconds: 2),
+  );
 ```
 
   </template>

--- a/docs-site/content/0.21.0/api/cluster-operations.md
+++ b/docs-site/content/0.21.0/api/cluster-operations.md
@@ -10,7 +10,7 @@ Creates a point-in-time snapshot of a Typesense node's state and data in the spe
 
 You can then backup the snapshot directory that gets created and later restore it as a data directory, as needed.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -85,7 +85,7 @@ Triggers a follower node to initiate the raft voting process, which triggers lea
 
 The follower node that you run this operation against will become the new leader, once this command succeeds.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -157,7 +157,7 @@ Default: `-1` which disables slow request logging.
 
 Slow requests are logged to the primary log file, with the prefix `SLOW REQUEST`.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -199,7 +199,7 @@ curl "http://localhost:8108/config" \
 
 Get current RAM, CPU, Disk & Network usage metrics.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -256,7 +256,7 @@ Get stats about API endpoints.
 
 This endpoint returns average requests per second and latencies for all requests in the last 10 seconds.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -303,7 +303,7 @@ curl "http://localhost:8108/stats.json" \
 
 Get health information about a Typesense node.
 
-<Tabs :tabs="['Shell']">
+<Tabs :tabs="['Dart','Shell']">
   <template v-slot:Dart>
 
 ```dart

--- a/docs-site/content/0.21.0/api/collection-alias.md
+++ b/docs-site/content/0.21.0/api/collection-alias.md
@@ -20,7 +20,7 @@ Convenient isn't it? Let's now look at how we can create, update and manage alia
 
 ## Create or Update an alias
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -121,7 +121,7 @@ curl "http://localhost:8108/aliases/companies" -X PUT \
 ## Retrieve an alias
 We can find out which collection an alias points to by fetching it.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -190,7 +190,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## List all aliases
 List all aliases and the corresponding collections that they map to.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -265,7 +265,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 
 ## Delete an alias
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.21.0/api/collections.md
+++ b/docs-site/content/0.21.0/api/collections.md
@@ -22,7 +22,7 @@ Your documents can contain other fields not mentioned in the collection's schema
 on _disk_ but not indexed in _memory_.
 :::
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -336,7 +336,7 @@ You can control this default coercion behavior at write-time with the [`dirty_va
 ## Retrieve a collection
 Retrieve the details of a collection, given its name.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -412,7 +412,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## List all collections
 Returns a summary of all your collections. The collections are returned sorted by creation date, with the most recent collections appearing first.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -499,7 +499,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Drop a collection
 Permanently drops a collection. This action cannot be undone. For large collections, this might have an impact on read latencies.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.21.0/api/curation.md
+++ b/docs-site/content/0.21.0/api/curation.md
@@ -13,7 +13,7 @@ In the following example, we are overriding the search results by placing the do
 
 Note how we are applying these overrides to an `exact` match of the query `apple`. Instead, if we want to match all queries that contained the word `apple`, we will use the `contains` match instead.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -192,7 +192,7 @@ curl "http://localhost:8108/collections/companies/overrides/customize-apple" -X 
 ## List all overrides
 Listing all overrides associated with a given collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -283,7 +283,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Retrieve an override
 Fetch an individual override associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -370,7 +370,7 @@ curl "http://localhost:8108/collections/companies/overrides/customize-apple" -X 
 ## Delete an override
 Deleting an override associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.21.0/api/documents.md
+++ b/docs-site/content/0.21.0/api/documents.md
@@ -538,7 +538,7 @@ Typesense supports geo search on fields containing the `geopoint` type.
 
 Let's create a collection called `places` with a field called `location` of type `geopoint`.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -646,6 +646,23 @@ client.collections.create(schema)
 ```
 
   </template>
+  <template v-slot:Dart>
+
+```dart
+final schema = Schema(
+  'places',
+  {
+    Field('title', Type.string),
+    Field('points', Type.int32),
+    Field('location', Type.geopoint),
+  },
+  defaultSortingField: Field('points', Type.int32),
+);
+
+await client.collections.create(schema);
+```
+
+  </template>
 
   <template v-slot:Shell>
 
@@ -668,7 +685,7 @@ curl -k "http://localhost:8108/collections" -X POST
 
 Let's now index a document.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -724,6 +741,19 @@ client.collections['places'].documents.create(document)
 ```
 
   </template>
+  <template v-slot:Dart>
+
+```dart
+final document = {
+  'title': 'Louvre Museuem',
+  'points': 1,
+  'location': [48.86093481609114, 2.33698396872901]
+};
+
+await client.collection('places').documents.create(document};
+```
+
+  </template>
 
   <template v-slot:Shell>
 
@@ -741,14 +771,14 @@ We can now search for places within a given radius of a given latlong
 (use `mi` for miles and `km` for kilometers). In addition, let's also sort the records that are closest to a given 
 location (this location can be the same or different from the latlong used for filtering).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
 let searchParameters = {
   'q'         : '*',
   'query_by'  : 'title',
-  'filter_by' : 'location:(48.90615915923891, 2.3435897727061175, 5 km)',
+  'filter_by' : 'location:(48.90615915923891, 2.3435897727061175, 5.1 km)',
   'sort_by'   : 'location(48.853, 2.344):asc'
 }
 
@@ -763,7 +793,7 @@ client.collections('companies').documents().search(searchParameters)
 $searchParameters = [
   'q'         => '*',
   'query_by'  => 'title',
-  'filter_by' => 'location:(48.90615915923891, 2.3435897727061175, 5 km)',
+  'filter_by' => 'location:(48.90615915923891, 2.3435897727061175, 5.1 km)',
   'sort_by'   => 'location(48.853, 2.344):asc'
 ];
 
@@ -778,7 +808,7 @@ $client->collections['companies']->documents->search($searchParameters);
 search_parameters = {
   'q'         : '*',
   'query_by'  : 'title',
-  'filter_by' : 'location:(48.90615915923891, 2.3435897727061175, 5 km)',
+  'filter_by' : 'location:(48.90615915923891, 2.3435897727061175, 5.1 km)',
   'sort_by'   : 'location(48.853, 2.344):asc'
 }
 
@@ -793,11 +823,25 @@ client.collections['companies'].documents.search(search_parameters)
 search_parameters = {
   'q'         => '*',
   'query_by'  => 'title',
-  'filter_by' => 'location:(48.90615915923891, 2.3435897727061175, 5 km)',
+  'filter_by' => 'location:(48.90615915923891, 2.3435897727061175, 5.1 km)',
   'sort_by'   => 'location(48.853, 2.344):asc'
 }
 
 client.collections['companies'].documents.search(search_parameters)
+```
+
+  </template>
+  <template v-slot:Dart>
+
+```dart
+final searchParameters = {
+  'q'         : '*',
+  'query_by'  : 'title',
+  'filter_by' : 'location:(48.90615915923891, 2.3435897727061175, 5.1 km)',
+  'sort_by'   : 'location(48.853, 2.344):asc'
+};
+
+client.collections('companies').documents().search(searchParameters)
 ```
 
   </template>
@@ -807,13 +851,45 @@ client.collections['companies'].documents.search(search_parameters)
 ```bash
 curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 "http://localhost:8108/collections/places/documents/search?q=*&query_by=title&\
-filter_by=location:(48.853,2.344,5 km)&sort_by=sort_by=location(48.853, 2.344):asc"
+filter_by=location:(48.853,2.344,5.1 km)&sort_by=sort_by=location(48.853, 2.344):asc"
 ```
 
   </template>
 </Tabs>
 
-The above example uses "5 km" as the radius, but you can also use miles, e.g. 
+#### Sample Response
+
+<Tabs :tabs="['JSON']">
+  <template v-slot:JSON>
+
+```json
+{
+  "facet_counts": [],
+  "found": 1,
+  "hits": [
+    {
+      "document": {
+        "id": 0,
+        "location": [48.86093481609114, 2.33698396872901],
+        "points": 1,
+        "title": "Louvre Museuem"
+      },
+      "geo_distance_meters": {"location": 1020},
+      "highlights": [],
+      "text_match": 16737280
+    }
+  ],
+  "out_of": 1,
+  "page": 1,
+  "request_params": {"collection_name": "places", "per_page": 10, "q": "*"},
+  "search_time_ms": 0
+}
+```
+
+  </template>
+</Tabs>
+
+The above example uses "5.1 km" as the radius, but you can also use miles, e.g. 
 `location:(48.90615915923891, 2.3435897727061175, 2 mi)`.
 
 You can also filter for documents within any arbitrary shaped polygon! The polygon's points must be defined in a 

--- a/docs-site/content/0.21.0/api/documents.md
+++ b/docs-site/content/0.21.0/api/documents.md
@@ -11,7 +11,7 @@ A document to be indexed in a given collection must conform to the schema of the
 
 If the document contains an `id` field of type `string`, Typesense would use that field as the identifier for the document. Otherwise, Typesense would assign an identifier of its choice to the document. Note that the id should not include spaces or any other characters that require [encoding in urls](https://www.w3schools.com/tags/ref_urlencode.asp).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby',  'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -104,7 +104,7 @@ curl "http://localhost:8108/collections/companies/documents" -X POST \
 You can also upsert a document.
 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby',  'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -219,7 +219,7 @@ To index multiple documents at the same time, in a batch/bulk operation, see [im
 ## Search
 In Typesense, a search consists of a query against one or more text fields and a list of filters against numerical or facet fields. You can also sort and facet your results.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -387,7 +387,7 @@ To group on a particular field, it must be a faceted field.
 
 Grouping returns the hits in a nested structure, that's different from the plain JSON response format we saw earlier. Let's repeat the query we made earlier with a `group_by` parameter:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -868,7 +868,7 @@ You can send multiple search requests in a single HTTP request, using the Multi-
 
 You can also use this feature to do a **federated search** across multiple collections in a single HTTP request.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1119,7 +1119,7 @@ The `results` array in a `multi_search` response is guaranteed to be in the same
 ## Retrieve a document
 Fetch an individual document from a collection by using its id.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1190,7 +1190,7 @@ $ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X GET \
 ## Update a document
 Update an individual document from a collection by using its id. The update can be partial, as shown below:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1289,7 +1289,7 @@ curl "http://localhost:8108/collections/companies/documents/124" -X PATCH \
 ## Delete documents
 Delete an individual document from a collection by using its id.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1360,7 +1360,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X DELETE \
 
 You can also delete a bunch of documents that match a specific filter condition:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1431,7 +1431,7 @@ Use the `batch_size` parameter to control the number of documents that should de
 
 ## Export documents
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1522,7 +1522,7 @@ This is essentially one JSON object per line, without commas between documents. 
 
 If you are using one of our client libraries, you can also pass in an array of documents and the library will take care of converting it into JSONL.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1649,7 +1649,7 @@ Here's an example file:
 
 You can import the above `documents.jsonl` file like this.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1730,7 +1730,7 @@ Once you have the JSONL file, you can then import it following the [instructions
 
 By default, Typesense ingests 40 documents at a time into Typesense. To increase this value, use the `batch_size` parameter.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1836,7 +1836,7 @@ the default behavior is `reject` (this ensures backward compatibility with older
 Let's now attempt to index a document with a `title` field that contains an integer. We will assume that this
 field was previously inferred to be of type `string`. Let's use the `coerce_or_reject` behavior here:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js

--- a/docs-site/content/0.21.0/api/synonyms.md
+++ b/docs-site/content/0.21.0/api/synonyms.md
@@ -16,7 +16,7 @@ Typesense supports two types of synonyms:
 
 ### Multi-way synonym
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -108,7 +108,7 @@ curl "http://localhost:8108/collections/products/synonyms/coat-synonyms" -X PUT 
 
 ### One-way synonym
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -217,7 +217,7 @@ curl "http://localhost:8108/collections/products/synonyms/smart-phone-synonyms" 
 ## Retrieve a synonym
 We can retrieve a single synonym.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -285,7 +285,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/colle
 ## List all synonyms
 List all synonyms associated with a given collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -358,7 +358,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Delete a synonym
 Delete a synonym associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Shell']">
   <template v-slot:JavaScript>
 
 ```js


### PR DESCRIPTION
Last remaining steps:

- [x] Readme in typesense-dart
- [x] Publish to pub.dev
- [x] Add Authentication dart example to v0.21.0 content (currently only exists in v0.20.0)
- [x] Add Geosearch examples to v0.21.0 (new feature, which didn't exist in v0.20.0)
- [x] Add credits to README - @jasonbosco 
- [x] Add compatibility matrix to README

CC: @happy-san Feel free to edit