### PR TITLE
Update cluster-operations.md

### DIFF
--- a/docs-site/content/0.21.0/api/cluster-operations.md
+++ b/docs-site/content/0.21.0/api/cluster-operations.md
@@ -171,6 +171,7 @@ await client.operations.toggleSlowRequestLog(Duration(seconds: 2));
 ```bash
 curl "http://localhost:8108/config" \
         -X POST \
+        -H 'Content-Type: application/json' \
         -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
         -d '{"log-slow-requests-time-ms": 2000}'
 ```


### PR DESCRIPTION
Added header 'Content-Type: application/json'  to fix curl import

## Change Summary
The curl command under Toggle Slow Request Log has this header missing, when not added the body is considered as string, not JSON while importing in postman or any other tool.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
