### PR TITLE
Fixed Typo in Feature Description #96

### DIFF
--- a/typesense.org/components/Home/SectionFeatureList.vue
+++ b/typesense.org/components/Home/SectionFeatureList.vue
@@ -21,7 +21,7 @@ export default {
         {
           name: 'Typo Tolerance',
           description:
-            'Spellng Mistakes? Not a problem. Typesense automatically tries to correct typos.',
+            'Spelling Mistakes? Not a problem. Typesense automatically tries to correct typos.',
           icon: require('~/assets/images/typo_tolerance_icon.svg'),
         },
         {


### PR DESCRIPTION
description:
            'Spellng Mistakes? Not a problem. Typesense automatically tries to correct typos.',
<---------------->
CHANGED TO
 <--------------->
description:
            'Spelling Mistakes? Not a problem. Typesense automatically tries to correct typos.',

## Change Summary
Spelling mistake corrected & solved #96 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
