### PR TITLE
Change Mac download instructions to use curl

### DIFF
--- a/docs-site/content/0.21.0/guide/install-typesense.md
+++ b/docs-site/content/0.21.0/guide/install-typesense.md
@@ -30,7 +30,7 @@ We also publish official Docker images for Typesense on [Docker hub](https://hub
 <Tabs :tabs="['Shell']">
   <template v-slot:Shell>
 
-<pre class="language-bash"><code>wget https://dl.typesense.org/releases/{{ $page.typesenseVersion }}/typesense-server-{{ $page.typesenseVersion }}-darwin-amd64.tar.gz
+<pre class="language-bash"><code>curl -O https://dl.typesense.org/releases/{{ $page.typesenseVersion }}/typesense-server-{{ $page.typesenseVersion }}-darwin-amd64.tar.gz
 </code></pre>
 
   </template>


### PR DESCRIPTION
wget is not installed by default on macOS.

I realize most developers could figure out what to do with the instructions as is, but I can tell you at Typesense care about getting the small details right.

## Change Summary
<!--- Described your changes here -->
wget is not installed by default on macOS.

I realize most developers could figure out what to do with the instructions as is, but I can tell you at Typesense care about getting the small details right.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
