### PR TITLE
explode & json_decode is not correct

### DIFF
--- a/docs-site/content/guide/building-a-search-application.md
+++ b/docs-site/content/guide/building-a-search-application.md
@@ -297,11 +297,11 @@ readline.createInterface({
 
 ```php
 $booksData = file_get_contents('/tmp/books.jsonl')
-$booksStrs = explode('\n', $booksData)
+$books = explode(PHP_EOL, $booksData);
 
-foreach($booksStrs as $bookStr) {
-  $book = json_decode($bookStr);
-  $client->collections['books']->documents->create($book)
+foreach($books as $bookItem) {
+    $book = json_decode($bookItem, true);
+    $client->collections['books']->documents->create($book);
 }
 ```
 


### PR DESCRIPTION
explode PHP_EOL should be used.
json_decode by default use object but create() function need array so true flag to make an associative array

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
