### PR TITLE
added docs about how to debug css on devtools

### DIFF
--- a/docs-site/content/guide/docsearch.md
+++ b/docs-site/content/guide/docsearch.md
@@ -235,4 +235,8 @@ You can override the following styles as needed:
 }
 ```
 
+:::tip Debugging CSS
+In order to inspect and debug your CSS without having the searchbar close when you click on the devtool panels, you can initialize the docsearch library with the ``debug: true`` option!
+:::
+
 Notice that you still need to use `.algolia-autocomplete` class names since we use [autocomplete.js](https://github.com/algolia/autocomplete) unmodified, but for docsearch classnames the class names are `.typesense-docsearch-*` since this is a modified version of DocSearch.js.


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

I was having some trouble debugging the CSS on the docsearch UI, but after reading the code, I found that there was a debug init option that solved my issue. 

I thought this knowledge would make a great addition to the docs. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9). (TODO)
