### PR TITLE
correct example retrieve synonym shell

### DIFF
--- a/docs-site/content/0.19.0/api/synonyms.md
+++ b/docs-site/content/0.19.0/api/synonyms.md
@@ -225,7 +225,7 @@ client.collections('products').synonyms('coat-synonyms').retrieve
   <template v-slot:Shell>
 
 ```bash
-curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms"
+curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms/coat-synonyms"
 ```
 
   </template>

--- a/docs-site/content/0.20.0/api/synonyms.md
+++ b/docs-site/content/0.20.0/api/synonyms.md
@@ -257,7 +257,7 @@ await client.collection('products').synonym('coat-synonyms').retrieve();
   <template v-slot:Shell>
 
 ```bash
-curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms"
+curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms/coat-synonyms"
 ```
 
   </template>

--- a/docs-site/content/0.21.0/api/synonyms.md
+++ b/docs-site/content/0.21.0/api/synonyms.md
@@ -288,7 +288,7 @@ SearchSynonym searchSynonym = client.collections("products").synonyms("coat-syno
   <template v-slot:Shell>
 
 ```bash
-curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms"
+curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms/coat-synonyms"
 ```
 
   </template>


### PR DESCRIPTION
Hi,

Corrected

```bash
curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms"
```

To

```bash
curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/collections/products/synonyms/coat-synonyms"
```

This was done to follow the spec `GET ${TYPESENSE_HOST}/collections/:collection/synonyms/:id`