### PR TITLE
Update documents doc site

### DIFF
--- a/docs-site/content/0.22.1/api/documents.md
+++ b/docs-site/content/0.22.1/api/documents.md
@@ -793,7 +793,7 @@ curl -k "http://localhost:8108/collections" -X POST
   </template>
 </Tabs>
 
-Let's now index a document.
+Let's now index a document. Make sure to set the coordinates in the correct order: `[Latitude, Longitude]`. GeoJSON often uses `[Longitude, Latitude]` which is invalid!
 
 <Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
   <template v-slot:JavaScript>


### PR DESCRIPTION
Makes clear that one has to use the correct order of coordinates for geopoints, since the underlying library will throw an error If the latitude is not between -90 and 90 degrees inclusive
or the longitude is not between -180 and 180 degrees inclusive.

## Change Summary
<!--- Described your changes here -->
Minor changes in the documents.md of 0.22.1
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
