### PR TITLE
Add Swift Client to Documentation

### DIFF
--- a/docs-site/content/0.22.1/api/api-clients.md
+++ b/docs-site/content/0.22.1/api/api-clients.md
@@ -28,6 +28,7 @@ We also have the following community-contributed client libraries:
 - [Rust](https://github.com/typesense/typesense-rust)
 - [Dart](https://github.com/typesense/typesense-dart)
 - [Perl](https://github.com/Ovid/Search-Typesense)
+- [Swift](https://github.com/typesense/typesense-swift)
 
 We also have the following community-contributed framework integrations:
 
@@ -37,7 +38,7 @@ We also have the following community-contributed framework integrations:
 
 <br>
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart', 'Java']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart', 'Java', 'Swift']">
   <template v-slot:JavaScript>
 
 ```js
@@ -99,6 +100,21 @@ import 'package:typesense/typesense.dart';
 import org.typesense.api.*;
 import org.typesense.models.*;
 import org.typesense.resources.*;
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+// For an iOS app, add typesense-swift as a framework dependency:
+// Target -> General -> Frameworks, Libraries, and Embedded Content -> "+" -> Add Package Dependency -> typesense-swift
+
+//For swift packages, add typesense-swift to the dependencies array in Package.swift:
+...
+dependencies: [
+           .package(url: "https://github.com/typesense/typesense-swift", .upToNextMajor(from: "0.1.0"),
+],
+...
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/api-keys.md
+++ b/docs-site/content/0.22.1/api/api-keys.md
@@ -322,7 +322,7 @@ ApiKey apiKey = client.keys(1).retrieve();
   <template v-slot:Swift>
 
 ```swift
-let (apiKey, response) = try await myClient.keys().retrieve(id: 1)
+let (apiKey, response) = try await client.keys().retrieve(id: 1)
 ```
 
   </template>
@@ -409,7 +409,7 @@ ApiKeysResponse apiKeysResponse = client.keys().retrieve();
   <template v-slot:Swift>
 
 ```swift
-let (apiKeys, response) = try await myClient.keys().retrieve()
+let (apiKeys, response) = try await client.keys().retrieve()
 ```
 
   </template>
@@ -516,7 +516,7 @@ ApiKey apiKey = client.keys(1).delete();
   <template v-slot:Swift>
 
 ```swift
-let (apiKey, response) = try await myClient.keys().delete(id: 1)
+let (apiKey, response) = try await client.keys().delete(id: 1)
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/api-keys.md
+++ b/docs-site/content/0.22.1/api/api-keys.md
@@ -17,7 +17,7 @@ We will be using the initial bootstrap key that you started Typesense with (via 
 
 Let's begin by creating an API key that allows you to do all operations, i.e. it's effectively an admin key and is equivalent to the key that you start Typesense with (via `--api-key`).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -91,6 +91,18 @@ ApiKey apiKey = client.keys().create(apiKeySchema);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let adminKey = ApiKeySchema(
+  _description: "Admin Key",
+  actions: ["*"],
+  collections: ["*"]
+)
+let (apiKey, response) = try await client.keys().create(adminKey)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -114,7 +126,7 @@ The generated key is only returned during creation. You want to store this key c
 
 Let's now see how we can create a search-only key that allows you to limit the key's scope to only the search action, and also for only a specific collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -187,6 +199,18 @@ ApiKey apiKey = client.keys().create(apiKeySchema);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let searchKey = ApiKeySchema(
+  _description: "Admin Key",
+  actions: ["documents:search"],
+  collections: ["companies"]
+)
+let (apiKey, response) = try await client.keys().create(searchKey)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -251,7 +275,7 @@ By setting the `actions` scope to `["documents:search"]` and the `collections` s
 ## Retrieve an API Key
 Retrieve (metadata about) a key.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -295,6 +319,13 @@ ApiKey apiKey = client.keys(1).retrieve();
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (apiKey, response) = try await myClient.keys().retrieve(id: 1)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -332,7 +363,7 @@ Notice how only the key prefix is returned when you retrieve a key. Due to secur
 ## List all Keys
 Retrieve (metadata about) all keys.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -372,6 +403,13 @@ await client.keys.retrieve();
 
 ```java
 ApiKeysResponse apiKeysResponse = client.keys().retrieve();
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (apiKeys, response) = try await myClient.keys().retrieve()
 ```
 
   </template>
@@ -431,7 +469,7 @@ Notice how only the key prefix is returned when you retrieve a key. Due to secur
 ## Delete API Key
 Delete an API key given its ID.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -472,6 +510,13 @@ final key = await client.key(1).delete();
 
 ```java
 ApiKey apiKey = client.keys(1).delete();
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (apiKey, response) = try await myClient.keys().delete(id: 1)
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/authentication.md
+++ b/docs-site/content/0.22.1/api/authentication.md
@@ -10,7 +10,7 @@ You'd need one or more hostnames and [API keys](./api-keys.md) to integrate with
 If you're self-hosting Typesense, the hostnames are the IP addresses or DNS names of each of your Typesense nodes. 
 If you're using Typesense Cloud, we generate unique hostnames for each of your nodes and show them on the dashboard for you to use. 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -150,6 +150,23 @@ Client client = new Client(configuration);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+import Typesense
+
+let node = Node(
+  host: "localhost",    // For Typesense Cloud use xxx.a1.typesense.net
+  port: "8108",         // For Typesense Cloud use 443
+  nodeProtocol: "http"  // For Typesense Cloud use https
+)
+
+let config = Configuration(nodes: [node], apiKey: "<API_KEY>", connectionTimeoutSeconds: 2)
+
+let client = Client(config: config)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -182,8 +199,7 @@ On Typesense Cloud, you can turn ON a setting called `Search Delivery Network` a
 
 You'll be a given a special hostname called the Nearest Node hostname when you turn this setting on for your cluster. You'd then need to configure your clients to use this hostname:
 
-
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Java', 'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Java', 'Swift', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -321,6 +337,24 @@ Node nearestNode = new Node("https", "xxx.a1.typesense.net", "443");
 Configuration configuration = new Configuration(nearestNode, nodes, Duration.ofSeconds(2),"<API_KEY>");
 
 Client client = new Client(configuration);
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+import Typesense
+
+var nodes: [Node] = []
+nodes.append(Node(host: "xxx-1.a1.typesense.net", port: "443", nodeProtocol: "https"))
+nodes.append(Node(host: "xxx-2.a1.typesense.net", port: "443", nodeProtocol: "https"))
+nodes.append(Node(host: "xxx-3.a1.typesense.net", port: "443", nodeProtocol: "https"))
+
+let nearestNode = Node(host: "xxx.a1.typesense.net", port: "443", nodeProtocol: "https")
+
+let config = Configuration(nodes: nodes, apiKey: "<API_KEY>", connectionTimeoutSeconds: 2, nearestNode: nearestNode)
+
+let client = Client(config: config)
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/cluster-operations.md
+++ b/docs-site/content/0.22.1/api/cluster-operations.md
@@ -11,7 +11,7 @@ Creates a point-in-time snapshot of a Typesense node's state and data in the spe
 
 You can then backup the snapshot directory that gets created and later restore it as a data directory, as needed.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -58,6 +58,13 @@ client.operations.perform("snapshot",query);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+try await client.operations().snapshot(path: "/tmp/typesense-data-snapshot")
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -96,7 +103,7 @@ Triggers a follower node to initiate the raft voting process, which triggers lea
 
 The follower node that you run this operation against will become the new leader, once this command succeeds.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -140,6 +147,13 @@ client.operations.perform("vote");
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+try await client.operations().vote()
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -175,11 +189,18 @@ Default: `-1` which disables slow request logging.
 
 Slow requests are logged to the primary log file, with the prefix `SLOW REQUEST`.
 
-<Tabs :tabs="['Dart','Shell']">
+<Tabs :tabs="['Dart','Swift','Shell']">
   <template v-slot:Dart>
 
 ```dart
 await client.operations.toggleSlowRequestLog(Duration(seconds: 2));
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+try await client.operations().toggleSlowRequestLog(seconds: 2)
 ```
 
   </template>
@@ -218,7 +239,7 @@ curl "http://localhost:8108/config" \
 
 Get current RAM, CPU, Disk & Network usage metrics.
 
-<Tabs :tabs="['Dart','Java','Shell']">
+<Tabs :tabs="['Dart','Java','Swift','Shell']">
   <template v-slot:Dart>
 
 ```dart
@@ -229,6 +250,12 @@ await client.metrics.retrieve();
 
 ```java
 client.metrics.retrieve();
+```
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (metrics, response) = try await client.operations().getMetrics()
 ```
   </template>
   <template v-slot:Shell>
@@ -282,11 +309,17 @@ Get stats about API endpoints.
 
 This endpoint returns average requests per second and latencies for all requests in the last 10 seconds.
 
-<Tabs :tabs="['Dart','Shell']">
+<Tabs :tabs="['Dart','Swift','Shell']">
   <template v-slot:Dart>
 
 ```dart
 await client.stats.retrieve();
+```
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (stats, response) = try await client.operations().getStats()
 ```
   </template>
   <template v-slot:Shell>
@@ -329,11 +362,17 @@ curl "http://localhost:8108/stats.json" \
 
 Get health information about a Typesense node.
 
-<Tabs :tabs="['Dart','Shell']">
+<Tabs :tabs="['Dart','Swift','Shell']">
   <template v-slot:Dart>
 
 ```dart
 await client.health.retrieve();
+```
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (healthStatus, response) = try await client.operations().getHealth()
 ```
   </template>
   <template v-slot:Shell>

--- a/docs-site/content/0.22.1/api/collection-alias.md
+++ b/docs-site/content/0.22.1/api/collection-alias.md
@@ -21,7 +21,7 @@ Convenient isn't it? Let's now look at how we can create, update and manage alia
 
 ## Create or Update an alias
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -93,6 +93,16 @@ client.aliases().upsert("companies", collectionAlias);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let collection = CollectionAliasSchema(collectionName: "companies_june11")
+
+// Creates/updates an alias called `companies` to the `companies_june11` collection
+let (collectionAlias, response) = try await client.aliases().upsert(name: "companies", collection: collection)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -132,7 +142,7 @@ curl "http://localhost:8108/aliases/companies" -X PUT \
 ## Retrieve an alias
 We can find out which collection an alias points to by fetching it.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -176,6 +186,13 @@ CollectionAlias collectionAlias = client.aliases("companies").retrieve();
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (collectionAlias, response) = try await client.aliases().retrieve(name: "companies")
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -208,7 +225,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## List all aliases
 List all aliases and the corresponding collections that they map to.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -252,6 +269,13 @@ CollectionAliasesResponse collectionAliasesResponse = client.aliases().retrieve(
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (collectionAliases, response) = try await client.aliases().retrieve()
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -290,7 +314,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 
 ## Delete an alias
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -331,6 +355,13 @@ await client.alias('companies').delete();
 
 ```java
 CollectionAlias collectionAlias = client.aliases("companies").delete();
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (collectionAlias, response) = try await client.aliases().delete(name: "companies")
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/collections.md
+++ b/docs-site/content/0.22.1/api/collections.md
@@ -186,8 +186,9 @@ let schema = CollectionSchema(
   ],
   defaultSortingField: "num_employees"
 )
-
-let (data, response) = try await client.collections.create(schema: schema)
+let (collectionResponse, response) = try await client.collections.create(schema: schema)
+// collectionResponse is a CollectionResponse object and response refers to
+// the HTTP response (URLResponse?) and can be used for debugging
 ```
 
   </template>
@@ -495,7 +496,7 @@ CollectionResponse collection = client.collections("companies").retrieve();
   <template v-slot:Swift>
 
 ```swift
-let (data, response) = try await client.collection(name: "companies").retrieve()
+let (collectionResponse, response) = try await client.collection(name: "companies").retrieve()
 ```
 
   </template>
@@ -585,7 +586,8 @@ CollectionResponse[] collectionResponses = client.collections().retrieve();
   <template v-slot:Swift>
 
 ```swift
-let (data, response) = try await client.collections().retrieveAll()
+let (collections, response) = try await client.collections().retrieveAll()
+// collections is of type [CollectionResponse]
 ```
 
   </template>
@@ -686,7 +688,7 @@ CollectionResponse collectionResponse = client.collections("companies").delete()
   <template v-slot:Swift>
 
 ```swift
-let (data, response) = try await client.collection(name: "companies").delete()
+let (collectionResponse, response) = try await client.collection(name: "companies").delete()
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/collections.md
+++ b/docs-site/content/0.22.1/api/collections.md
@@ -31,7 +31,7 @@ on _disk_ but not indexed in _memory_. So, while they will be part of the docume
 you can't query on them.
 :::
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -171,6 +171,23 @@ collectionschema.name("companies")
                 .addFieldsItem(new Field().name("country").type(Field.TypeEnum.STRING).facet(true));
 
 CollectionResponse collectionResponse = client.collections().create(collectionSchema);
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let schema = CollectionSchema(
+  name: "companies",
+  fields: [
+    Field(name: "company_name", type: "string"),
+    Field(name: "num_employees", type: "int32"),
+    Field(name: "country", type: "string", facet: true)
+  ],
+  defaultSortingField: "num_employees"
+)
+
+let (data, response) = try await client.collections.create(schema: schema)
 ```
 
   </template>
@@ -431,7 +448,7 @@ You can control this default coercion behavior at write-time with the [`dirty_va
 ## Retrieve a collection
 Retrieve the details of a collection, given its name.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -473,6 +490,14 @@ await client.collection('companies').retrieve();
 ```java
 CollectionResponse collection = client.collections("companies").retrieve();
 ```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collection(name: "companies").retrieve()
+```
+
   </template>
   <template v-slot:Shell>
 
@@ -513,7 +538,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## List all collections
 Returns a summary of all your collections. The collections are returned sorted by creation date, with the most recent collections appearing first.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -554,6 +579,13 @@ await client.collections.retrieve();
 
 ```java
 CollectionResponse[] collectionResponses = client.collections().retrieve();
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collections().retrieveAll()
 ```
 
   </template>
@@ -607,7 +639,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Drop a collection
 Permanently drops a collection. This action cannot be undone. For large collections, this might have an impact on read latencies.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -651,6 +683,14 @@ CollectionResponse collectionResponse = client.collections("companies").delete()
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collection(name: "companies").delete()
+```
+
+  </template>
+  
   <template v-slot:Shell>
 
 ```bash

--- a/docs-site/content/0.22.1/api/documents.md
+++ b/docs-site/content/0.22.1/api/documents.md
@@ -12,7 +12,7 @@ A document to be indexed in a given collection must conform to the schema of the
 
 If the document contains an `id` field of type `string`, Typesense would use that field as the identifier for the document. Otherwise, Typesense would assign an identifier of its choice to the document. Note that the id should not include spaces or any other characters that require [encoding in urls](https://www.w3schools.com/tags/ref_urlencode.asp).
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Java', 'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Java', 'Swift', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -97,6 +97,30 @@ client.collections("companies").documents().create(document);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+//Primarily make sure that the document type is defined as a Codable struct/class
+struct Company: Codable {
+  var id: String?
+  var company_name: String?
+  var num_employees: Int?
+  var country: String?
+}
+
+let document = Company(
+  id: "124",
+  company_name: "Stark Industries",
+  num_employees: 5215,
+  country: "USA"
+)
+
+let documentData = try encoder.encode(document)
+let (data, response) = try await client.collection(name: "companies").documents().create(document: documentData)
+let documentResponse = try decoder.decode(Company.self, from: data!)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -118,7 +142,7 @@ curl "http://localhost:8108/collections/companies/documents" -X POST \
 You can also upsert a document.
 
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Java', 'Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart', 'Java', 'Swift', 'Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -204,6 +228,22 @@ client.collections("companies").documents().upsert(document);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let document = Company(
+  id: "124",
+  company_name: "Stark Industries",
+  num_employees: 5215,
+  country: "USA"
+)
+
+let documentData = try encoder.encode(document)
+let (data, response) = try await client.collection(name: "companies").documents().upsert(document: documentData)
+let documentResponse = try decoder.decode(Company.self, from: data!)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -247,7 +287,7 @@ To index multiple documents at the same time, in a batch/bulk operation, see [im
 ## Search
 In Typesense, a search consists of a query against one or more text fields and a list of filters against numerical or facet fields. You can also sort and facet your results.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -328,6 +368,19 @@ SearchParameters searchParameters = new SearchParameters()
                                         .filterBy("num_employees:>100")
                                         .addsortByItem("num_employees:desc");
 SearchResult searchResult = client.collections("companies").documents().search(searchParameters);
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let searchParameters = SearchParameters(
+  q: "stark",
+  queryBy: "company_name",
+  filterBy: "num_employees:>100",
+  sortBy: "num_employees:desc"
+)
+let (searchResult, response) = try await client.collection(name: "companies").documents().search(searchParameters, for: Company.self)
 ```
 
   </template>
@@ -427,7 +480,7 @@ To group on a particular field, it must be a faceted field.
 
 Grouping returns the hits in a nested structure, that's different from the plain JSON response format we saw earlier. Let's repeat the query we made earlier with a `group_by` parameter:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -521,6 +574,21 @@ SearchParameters searchParameters = new SearchParameters()
                                         .groupLimit(1);
 SearchResult searchResult = client.collections("companies").documents().search(searchParameters);
 ```
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let searchParameters = SearchParameters(
+  q: "stark",
+  queryBy: "company_name",
+  filterBy: "num_employees:>100",
+  sortBy: "num_employees:desc",
+  groupBy: "country",
+  groupLimit: 1
+)
+let (searchResult, response) = try await client.collection(name: "companies").documents().search(searchParameters, for: Company.self)
+```
+
   </template>
   <template v-slot:Shell>
 
@@ -1346,7 +1414,7 @@ The `results` array in a `multi_search` response is guaranteed to be in the same
 ## Retrieve a document
 Fetch an individual document from a collection by using its id.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1390,6 +1458,14 @@ Hashmap<String, Object> document = client.collections("companies").documents("12
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collection(name: "companies").document(id: "124").retrieve()
+let document = try decoder.decode(Company.self, from: data!)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -1424,7 +1500,7 @@ $ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X GET \
 ## Update a document
 Update an individual document from a collection by using its id. The update can be partial, as shown below:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1497,6 +1573,20 @@ HashMap<String, Object> updatedDocument = client.collections("companies").docume
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let document = Company(
+  company_name: "Stark Industries",
+  num_employees: 5500,
+)
+
+let documentData = try encoder.encode(document)
+let (data, response) = try await client.collection(name: "companies").document(id: "124").update(newDocument: documentData)
+let documentResponse = try decoder.decode(Company.self, from: data!)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -1534,7 +1624,7 @@ curl "http://localhost:8108/collections/companies/documents/124" -X PATCH \
 ## Delete documents
 Delete an individual document from a collection by using its id.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1578,6 +1668,14 @@ HashMap<String, Object> deletedDocument = client.collections("companies").docume
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collection(name: "companies").document(id: "124").delete()
+let document = try decoder.decode(Company.self, from: data!)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -1612,7 +1710,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X DELETE \
 
 You can also delete a bunch of documents that match a specific filter condition:
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1659,6 +1757,14 @@ client.collections("companies").documents().delete(deleteDocumentsParameters);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collection(name: "companies").documents().delete(filter: "num_employees:>100")
+let document = try decoder.decode(Company.self, from: data!)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -1693,7 +1799,7 @@ Use the `batch_size` parameter to control the number of documents that should de
 
 ## Export documents
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1738,6 +1844,13 @@ exportDocumentsParameters.addExcludeFieldsItem("id");
 exportDocumentsParameters.addIncludeFieldsItem("publication_year");
 exportDocumentsParameters.addIncludeFieldsItem("authors");
 client.collections("companies").documents().export(exportDocumentsParameters);
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (data, response) = try await client.collection(name: "companies").documents().export()
 ```
 
   </template>
@@ -1795,7 +1908,7 @@ This is essentially one JSON object per line, without commas between documents. 
 
 If you are using one of our client libraries, you can also pass in an array of documents and the library will take care of converting it into JSONL.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1890,6 +2003,33 @@ client.collections("Countries").documents().import_(documentList, importDocument
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let documents = [
+  Company(
+    id: "124",
+    company_name: "Stark Industries",
+    num_employees: 5125,
+    country: "USA"
+  )
+]
+
+var jsonLStrings:[String] = []
+for doc in documents {
+    let data = try encoder.encode(doc)
+    let str = String(data: data, encoding: .utf8)!
+    jsonLStrings.append(str)
+}
+
+let jsonLString = jsonLStrings.joined(separator: "\n")
+let jsonL = Data(jsonLString.utf8)
+
+let (data, response) = try await client.collection(name: "companies").documents().importBatch(jsonL)
+
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -1944,7 +2084,7 @@ Here's an example file:
 
 You can import the above `documents.jsonl` file like this.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -1999,6 +2139,16 @@ while (myReader.hasNextLine()) {
     data.append(myReader.nextLine()).append("\n");
 }
 client.collections("books").documents().import_(data.toString(), queryParameters);
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let urlPath = URL(fileURLWithPath: "<PATH_TO>/documents.jsonl")
+let jsonL = try Data(contentsOf: urlPath)
+
+let (data, response) = try await client.collection(name: "companies").documents().importBatch(jsonL)
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/synonyms.md
+++ b/docs-site/content/0.22.1/api/synonyms.md
@@ -204,7 +204,7 @@ SearchSynonymSchema synonym = new SearchSynonymSchema();
 synonym.addSynonymsItem("iphone").addSynonymsItem("android");
 synonym.root("smart phone");
 
-// Creates/updates a synonym called `blazer-synonyms` in the `products` collection
+// Creates/updates a synonym called `smart-phone-synonyms` in the `products` collection
 client.collections("products").synonyms().upsert("smart-phone-synonyms", synonym);
 ```
 

--- a/docs-site/content/0.22.1/api/synonyms.md
+++ b/docs-site/content/0.22.1/api/synonyms.md
@@ -17,7 +17,7 @@ Typesense supports two types of synonyms:
 
 ### Multi-way synonym
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -90,6 +90,16 @@ client.collections("products").synonyms().upsert("coat-synonyms", synonym);
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let synonymSchema = SearchSynonymSchema(synonyms: ["blazer", "coat", "jacket"])
+
+// Creates/updates a synonym called `coat-synonyms` in the `products` collection
+let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().upsert(id: "coat-synonyms", synonymSchema)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -120,7 +130,7 @@ curl "http://localhost:8108/collections/products/synonyms/coat-synonyms" -X PUT 
 
 ### One-way synonym
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -199,6 +209,19 @@ client.collections("products").synonyms().upsert("smart-phone-synonyms", synonym
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let synonymSchema = SearchSynonymSchema(
+  root: "smart phone",
+  synonyms: ["iphone", "android"]
+)
+
+// Creates/updates a synonym called `smart-phone-synonyms` in the `products` collection
+let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().upsert(id: "smart-phone-synonyms", synonymSchema)
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -241,7 +264,7 @@ curl "http://localhost:8108/collections/products/synonyms/smart-phone-synonyms" 
 ## Retrieve a synonym
 We can retrieve a single synonym.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -285,6 +308,13 @@ SearchSynonym searchSynonym = client.collections("products").synonyms("coat-syno
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().retrieve(id: "coat-synonyms")
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -316,7 +346,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" "http://localhost:8108/colle
 ## List all synonyms
 List all synonyms associated with a given collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -360,6 +390,13 @@ SearchSynonymsResponse searchSynonymsResponse =  client.collections("products").
 ```
 
   </template>
+  <template v-slot:Swift>
+
+```swift
+let (searchSynonyms, response) = try await myClient.collection(name: "products").synonyms().retrieve()
+```
+
+  </template>
   <template v-slot:Shell>
 
 ```bash
@@ -396,7 +433,7 @@ curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
 ## Delete a synonym
 Delete a synonym associated with a collection.
 
-<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Shell']">
+<Tabs :tabs="['JavaScript','PHP','Python','Ruby','Dart','Java','Swift','Shell']">
   <template v-slot:JavaScript>
 
 ```js
@@ -437,6 +474,13 @@ await client.collection('products').synonym('coat-synonyms').delete();
 
 ```java
 SearchSynonym searchSynonym = client.collections("products").synonyms("coat-synonyms").delete();
+```
+
+  </template>
+  <template v-slot:Swift>
+
+```swift
+let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().delete(id: "coat-synonyms")
 ```
 
   </template>

--- a/docs-site/content/0.22.1/api/synonyms.md
+++ b/docs-site/content/0.22.1/api/synonyms.md
@@ -96,7 +96,7 @@ client.collections("products").synonyms().upsert("coat-synonyms", synonym);
 let synonymSchema = SearchSynonymSchema(synonyms: ["blazer", "coat", "jacket"])
 
 // Creates/updates a synonym called `coat-synonyms` in the `products` collection
-let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().upsert(id: "coat-synonyms", synonymSchema)
+let (searchSynonym, response) = try await client.collection(name: "products").synonyms().upsert(id: "coat-synonyms", synonymSchema)
 ```
 
   </template>
@@ -218,7 +218,7 @@ let synonymSchema = SearchSynonymSchema(
 )
 
 // Creates/updates a synonym called `smart-phone-synonyms` in the `products` collection
-let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().upsert(id: "smart-phone-synonyms", synonymSchema)
+let (searchSynonym, response) = try await client.collection(name: "products").synonyms().upsert(id: "smart-phone-synonyms", synonymSchema)
 ```
 
   </template>
@@ -311,7 +311,7 @@ SearchSynonym searchSynonym = client.collections("products").synonyms("coat-syno
   <template v-slot:Swift>
 
 ```swift
-let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().retrieve(id: "coat-synonyms")
+let (searchSynonym, response) = try await client.collection(name: "products").synonyms().retrieve(id: "coat-synonyms")
 ```
 
   </template>
@@ -393,7 +393,7 @@ SearchSynonymsResponse searchSynonymsResponse =  client.collections("products").
   <template v-slot:Swift>
 
 ```swift
-let (searchSynonyms, response) = try await myClient.collection(name: "products").synonyms().retrieve()
+let (searchSynonyms, response) = try await client.collection(name: "products").synonyms().retrieve()
 ```
 
   </template>
@@ -480,7 +480,7 @@ SearchSynonym searchSynonym = client.collections("products").synonyms("coat-syno
   <template v-slot:Swift>
 
 ```swift
-let (searchSynonym, response) = try await myClient.collection(name: "products").synonyms().delete(id: "coat-synonyms")
+let (searchSynonym, response) = try await client.collection(name: "products").synonyms().delete(id: "coat-synonyms")
 ```
 
   </template>


### PR DESCRIPTION
## Documentation added

- Installation / Authentication
- Collections
- Documents
- ApiKeys
- Synonyms
- Aliases
- Cluster Operations
- Fixed a tiny mistake in Java one-way synonym caption

### Documentation pending in Swift Client

- Curations
- Geosearch
- Multisearch
- Batch-size while importing
- Dealing with dirty data
- Scoped search key