### PR TITLE
Update server /health response doc example

### DIFF
--- a/docs-site/content/0.22.1/api/cluster-operations.md
+++ b/docs-site/content/0.22.1/api/cluster-operations.md
@@ -351,7 +351,7 @@ curl "http://localhost:8108/health"
 
 ```json
 {
-  "status": "ok"
+  "ok": true
 }
 ```
 


### PR DESCRIPTION
using `0.22.1` and calling `/health` on the server, the json response I'm getting doesn't match what's in doc.
This updates doc to what i'm getting.

running `typesense-server-0.22.1-darwin-amd64/typesense-server`

screenshot of what i'm getting from wireshark:
![image](https://user-images.githubusercontent.com/48771/147926837-b68ccb1d-299e-42c4-a0d2-2ac07022f6e5.png)
