### PR TITLE
Fix typos in GitHub

### DIFF
--- a/docs-site/content/help.md
+++ b/docs-site/content/help.md
@@ -2,7 +2,7 @@
 
 If you run into any issues or have general questions, here are a couple of ways to ask for help:
 
-- Open a [Github issue](https://github.com/typesense/typesense/issues)
+- Open a [GitHub issue](https://github.com/typesense/typesense/issues)
 - Join our [Slack community](https://join.slack.com/t/typesense-community/shared_invite/zt-mx4nbsbn-AuOL89O7iBtvkz136egSJg) to discuss general questions and/or issues
 - Schedule a call with the core Typesense team [here](https://calendly.com/jason-typesense/typesense-office-hours)
 - We also offer prioritized paid support, with private Slack, email & phone-based support with guaranteed SLAs. Learn more [here](https://typesense.org/support)

--- a/typesense.org/components/Footer.vue
+++ b/typesense.org/components/Footer.vue
@@ -40,7 +40,7 @@
               <a
                 class="nav-link p-0"
                 href="https://github.com/typesense/typesense"
-                >Github Repo</a
+                >GitHub Repo</a
               >
             </li>
             <li class="nav-item">

--- a/typesense.org/components/Home/Badges.vue
+++ b/typesense.org/components/Home/Badges.vue
@@ -5,7 +5,7 @@
         <a href="https://github.com/typesense/typesense" target="_blank"
           ><img
             src="https://img.shields.io/github/stars/typesense/typesense?label=stars&style=for-the-badge&logo=github&color=020102"
-            alt="typesense/typesense on Github"
+            alt="typesense/typesense on GitHub"
             style="width: 173px; height: 36px"
             width="173"
             height="36"

--- a/typesense.org/components/Home/SectionHero.vue
+++ b/typesense.org/components/Home/SectionHero.vue
@@ -29,7 +29,7 @@
               <a href="https://github.com/typesense/typesense">
                 <img
                   src="https://img.shields.io/github/stars/typesense/typesense?style=social"
-                  alt="Github Stars"
+                  alt="GitHub Stars"
                   class="mt-4 d-block d-sm-none"
                   height="20"
                 />

--- a/typesense.org/components/Home/SectionSupport.vue
+++ b/typesense.org/components/Home/SectionSupport.vue
@@ -16,7 +16,7 @@
               :image-height="45"
               href="https://github.com/typesense/typesense/issues"
               target="_blank"
-              name="Github Issues"
+              name="GitHub Issues"
             ></HomeSupportOption>
           </div>
           <div class="col-sm-2 mt-4 mt-sm-0 d-flex justify-content-center">

--- a/typesense.org/components/Navbar.vue
+++ b/typesense.org/components/Navbar.vue
@@ -56,7 +56,7 @@
               <a href="https://github.com/typesense/typesense">
                 <img
                   src="https://img.shields.io/github/stars/typesense/typesense?style=social"
-                  alt="Github Stars"
+                  alt="GitHub Stars"
                   class="d-none d-sm-block"
                   height="20"
                 />

--- a/typesense.org/components/Support/SectionHero.vue
+++ b/typesense.org/components/Support/SectionHero.vue
@@ -9,7 +9,7 @@
             We know someone <small>✋</small>
           </h1>
           <div>
-            We strive to provide good support through our Github Issue tracker.
+            We strive to provide good support through our GitHub Issue tracker.
           </div>
           <div class="mt-1">
             We also offer paid prioritized support with guaranteed SLAs,

--- a/typesense.org/components/Support/SectionTiers.vue
+++ b/typesense.org/components/Support/SectionTiers.vue
@@ -33,7 +33,7 @@
                 <tr class="text-center">
                   <td class="text-right">Support Channels</td>
                   <td>
-                    Github Issues<br />
+                    GitHub Issues<br />
                     Slack Community<br />
                     Weekly Office Hours
                   </td>

--- a/typesense.org/pages/support.vue
+++ b/typesense.org/pages/support.vue
@@ -19,7 +19,7 @@ export default {
           hid: 'description',
           name: 'description',
           content:
-            "Need help building with Typesense? We've got your covered. Github issues, Slack community, Weekly Office Hours, Email, Phone Calls.",
+            "Need help building with Typesense? We've got your covered. GitHub issues, Slack community, Weekly Office Hours, Email, Phone Calls.",
         },
       ],
     }

--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -682,7 +682,7 @@
                 <tr>
                   <td class="font-weight-bold">Channels</td>
                   <td>
-                    Github issues<br />
+                    GitHub issues<br />
                     Email<br />
                     Public Slack Community<br />
                     Phone<br />
@@ -690,20 +690,20 @@
                     Paid Prioritized Support
                   </td>
                   <td>
-                    Github issues<br />
+                    GitHub issues<br />
                     Email<br />
                     Public Slack Community<br />
                     Phone<br />
                     Paid Prioritized Support
                   </td>
                   <td>
-                    Github issues<br />
+                    GitHub issues<br />
                     Email<br />
                     Public Slack Community<br />
                     Paid Prioritized Support
                   </td>
                   <td>
-                    Github issues<br />
+                    GitHub issues<br />
                     Email<br />
                     Public Slack Community
                   </td>


### PR DESCRIPTION
GitHub is GitHub. https://github.com/logos

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)