### PR TITLE
Update install-typesense.md to correct Homebrew config, data and logging directory

### DIFF
--- a/docs-site/content/guide/install-typesense.md
+++ b/docs-site/content/guide/install-typesense.md
@@ -134,9 +134,9 @@ ignore this error message , executing `apt list --installed | grep typesense` wo
 </Tabs>
 
 - The default API key is `xyz` and the default port is `8108`
-- The config file is at `/usr/local/etc/typesense/typesense.ini`
-- Logs are under `/usr/local/var/log/typesense/`
-- Data dir is under `/usr/local/var/lib/typesense/`
+- The config file is at `/opt/homebrew/etc/typesense/typesense.ini`
+- Logs are under `/opt/homebrew/var/log/typesense/`
+- Data dir is under `/opt/homebrew/var/lib/typesense/`
 
 #### From the pre-built binary
 If you downloaded the pre-built binary for Mac / Linux, you can start Typesense with minimal options like this:

--- a/docs-site/content/guide/install-typesense.md
+++ b/docs-site/content/guide/install-typesense.md
@@ -133,6 +133,12 @@ ignore this error message , executing `apt list --installed | grep typesense` wo
   </template>
 </Tabs>
 
+For macOS running on Intel:
+- The config file is at `/usr/local/etc/typesense/typesense.ini`
+- Logs are under `/usr/local/var/log/typesense/`
+- Data dir is under `/usr/local/var/lib/typesense/`
+
+For macOS running on Apple silicon:
 - The default API key is `xyz` and the default port is `8108`
 - The config file is at `/opt/homebrew/etc/typesense/typesense.ini`
 - Logs are under `/opt/homebrew/var/log/typesense/`

--- a/docs-site/content/guide/install-typesense.md
+++ b/docs-site/content/guide/install-typesense.md
@@ -134,6 +134,7 @@ ignore this error message , executing `apt list --installed | grep typesense` wo
 </Tabs>
 
 For macOS running on Intel:
+- The default API key is `xyz` and the default port is `8108`
 - The config file is at `/usr/local/etc/typesense/typesense.ini`
 - Logs are under `/usr/local/var/log/typesense/`
 - Data dir is under `/usr/local/var/lib/typesense/`


### PR DESCRIPTION
The config, data and logging directory for the Homebrew installation are incorrect/outdated. I just did a clean install on my M1 Macbook Pro and this is where they ended up.

## Change Summary
Update the config, logging and data directory for the Homebrew installation of Typesense on Mac..

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
