### PR TITLE
Typo in Search documentation

### DIFF
--- a/docs-site/content/0.23.1/api/search.md
+++ b/docs-site/content/0.23.1/api/search.md
@@ -312,7 +312,7 @@ sorting is allowed on the `email` string field.
   "name": "users",
   "fields": [
     {"name": "name", "type": "string" },
-    {"name": "email", "type": "int32", "sort": true }
+    {"name": "email", "type": "string", "sort": true }
   ]
 }
 ```


### PR DESCRIPTION
The example is meant to have a string field with the sort enabled. Currently the field with sorting turned on shows int32 as the type.

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
