### PR TITLE
remove create and add upsert for alias key permissions

### DIFF
--- a/docs-site/content/0.23.1/api/api-keys.md
+++ b/docs-site/content/0.23.1/api/api-keys.md
@@ -313,7 +313,7 @@ In general, you want to use the format `resource:verb` pattern to indicate an ac
 |:---------------------|:--------------------------------------------------|
 | `aliases:list`       | Allows all aliases to be fetched.                 |
 | `aliases:get`        | Allows a single alias to be retrieved             |
-| `aliases:create`     | Allows the creation of aliases.                   |
+| `aliases:upsert`     | Allows upserting aliases.                         |
 | `aliases:delete`     | Allows the deletion of aliases.                   |
 | `aliases:*`          | Allows all alias operations.                      |
 


### PR DESCRIPTION
## Change Summary
As discussed in [this slack thread](https://typesense-community.slack.com/archives/C01P749MET0/p1673312851871479)  `create` doesn't exist as an action/http method, however `upsert` (PUT) does.
This PR updates the API Key permissions section to reflect that.

Please note I have confirmed that `upsert` works (using the docsearch scraper) but I haven't personally verified that `create` doesn't exist. The removal of `create` is based purely on the slack conversation.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
