### PR TITLE
typo: `xkcd search` page refered as `books search`

### DIFF
--- a/docs-site/content/guide/reference-implementations/xkcd-search.md
+++ b/docs-site/content/guide/reference-implementations/xkcd-search.md
@@ -1,4 +1,4 @@
-# Books Search
+# xkcd Search
 
 This site indexes transcripts and topics from xkcd and let's you browse and search by topic, character names and date. 
 


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Typo error on [typesense/../../xkcd-search.html](https://typesense.org/docs/guide/reference-implementations/xkcd-search.html). Refers `xkcd` as `books` in the headline.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
