### PR TITLE
Fix xkcd typo on homepage

### DIFF
--- a/typesense.org/components/Home/SectionShowcase.vue
+++ b/typesense.org/components/Home/SectionShowcase.vue
@@ -86,8 +86,8 @@
           </HomeShowcaseBlock>
           <HomeShowcaseBlock emoji="⚡ ⌨️" link="https://findxkcd.com/">
             <template #title
-              ><small>findxckd</small><br />
-              Browse & Find xckd Comics by Topic
+              ><small>findxkcd</small><br />
+              Browse & Find xkcd Comics by Topic
             </template>
           </HomeShowcaseBlock>
           <HomeShowcaseBlock


### PR DESCRIPTION
Nothing to see here, just fixing a typo 🤠 🛠️

## Change Summary
`xckd` -> `xkcd`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
