### PR TITLE
fix yml indentation

### DIFF
--- a/docs-site/content/guide/install-typesense.md
+++ b/docs-site/content/guide/install-typesense.md
@@ -146,16 +146,18 @@ docker run -p 8108:8108 -v$(pwd)/typesense-data:/data typesense/typesense:{{ $si
 <Tabs :tabs="['yml']">
   <template v-slot:yml>
     <div class="manual-highlight">
-      <pre class="language-yaml"><code>version: '3.4'
-      services:
-        typesense:
-          image: typesense/typesense:{{ $site.themeConfig.typesenseLatestVersion }}
-          restart: on-failure
-          ports:
-            - "8108:8108"
-          volumes:
-            - ./typesense-data:/data
-          command: '--data-dir /data --api-key=xyz --enable-cors'</code></pre>
+      <pre class="language-yaml">
+<code>version: '3.4'
+services:
+  typesense:
+    image: typesense/typesense:{{ $site.themeConfig.typesenseLatestVersion }}
+    restart: on-failure
+    ports:
+      - "8108:8108"
+    volumes:
+      - ./typesense-data:/data
+    command: '--data-dir /data --api-key=xyz --enable-cors'</code>
+      </pre>
     </div>
   </template>
 </Tabs>


### PR DESCRIPTION
## Change Summary
I have changed the indentations so that the yml indentations are correct when pasting the docker-compose code block and creating your own locally. 

Current:
<img width="768" alt="Screenshot 2023-07-01 at 4 23 43 PM" src="https://github.com/typesense/typesense-website/assets/29524703/9dbab771-60d6-493e-97a5-35d9af2c72e0">

Updated:
<img width="763" alt="Screenshot 2023-07-01 at 4 24 01 PM" src="https://github.com/typesense/typesense-website/assets/29524703/b013cbf7-e127-4f0e-b62c-6788c14d8f24">


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
