### PR TITLE
Update Geo Search to show Geo Search limitation for MeiliSearch

### DIFF
--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -400,7 +400,7 @@
                   <td>✅</td>
                   <td>✅️</td>
                   <td>✅️</td>
-                  <td>✅</td>
+                  <td>🔶 Limited to one geo point</td>
                 </tr>
                 <tr>
                   <td class="font-weight-bold">


### PR DESCRIPTION
## Change Summary
MeiliSearch is currently limited to only supporting one `_geo` field per document and searching on it.

Although it's a [highly requested feature](https://github.com/meilisearch/product/discussions/508), there's currently no official plans to support multiple geo points and search. This can be a pretty substantial limitation for those that need the feature, so it's worth documenting.