### PR TITLE
Fix "Build A Search Application" docs: "port" is a number, not string

### DIFF
--- a/docs-site/content/guide/building-a-search-application.md
+++ b/docs-site/content/guide/building-a-search-application.md
@@ -36,7 +36,7 @@ const Typesense = require('typesense')
 let client = new Typesense.Client({
   'nodes': [{
     'host': 'localhost', // For Typesense Cloud use xxx.a1.typesense.net
-    'port': '8108',      // For Typesense Cloud use 443
+    'port': 8108,      // For Typesense Cloud use 443
     'protocol': 'http'   // For Typesense Cloud use https
   }],
   'apiKey': '<API_KEY>',


### PR DESCRIPTION
## Change Summary
I'm working with Typesense in Node, and was following this doc. TypeScript throws a type error, since the type of `port` is `number`, not `string`. I didn't check the other libraries for other languages, but it seems likely the same issue will exist elsewhere.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
