### PR TITLE
API key permissions documentation update: Add stats.json:list Action

### DIFF
--- a/docs-site/content/0.25.1/api/api-keys.md
+++ b/docs-site/content/0.25.1/api/api-keys.md
@@ -353,6 +353,7 @@ In general, you want to use the format `resource:verb` pattern to indicate an ac
 | Action               | Description                                       |
 |:---------------------|:--------------------------------------------------|
 | `metrics.json:list`  | Allows access to the metrics endpoint.            |
+| `stats.json:list`    | Allows access to the stats endpoint.              |
 | `debug:list`         | Allows access to the `/debug` endpoint.           |
 | `*`                  | Allows all operations.                            |
 


### PR DESCRIPTION
## Change Summary
Incorporate the omitted `stats.json:list` action for API key permissions. After testing, it appears that this action has already been implemented.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
