### PR TITLE
Improve DocSearch docs related to running scraper inside docker

### DIFF
--- a/docs-site/content/guide/docsearch.md
+++ b/docs-site/content/guide/docsearch.md
@@ -109,6 +109,15 @@ The easiest way to run the scraper is using Docker.
     docker run -it --env-file=/path/to/your/.env -e "CONFIG=$(cat config.json | jq -r tostring)" typesense/docsearch-scraper:0.9.1
     ```
 
+  :::tip
+  If you are running Typesense on `localhost` and you're using Docker to run the scraper, you will need to change some things in your `config.json` file.
+
+  On `start_urls` and `sitemap_urls`, you will need to target the `host.docker.internal` URL, to ensure that will find the right site in your host machine, instead
+  of trying to find it inside the container.
+
+  You will need to run your site at port `:80`, because the scraper can present a not expected behavior if has hosted in another port.
+  :::
+
 This will scrape your documentation site and index it into Typesense.
 
 ::: tip

--- a/docs-site/content/guide/docsearch.md
+++ b/docs-site/content/guide/docsearch.md
@@ -27,6 +27,15 @@ Follow one of the templates below to create your own `config.json` file, pointin
 
 Here's the official [DocSearch Scraper documentation](https://docsearch.algolia.com/docs/legacy/config-file) that describes all the available config options.
 
+:::tip
+If you are running Typesense on `localhost` and you're using Docker to run the scraper, you will need to change some things in your `config.json` file.
+
+On `start_urls` and `sitemap_urls`, you will need to target the `host.docker.internal` URL, to ensure that will find the right site in your host machine, instead
+of trying to find it inside the container.
+
+You will need to run your site at port `:80`, because the scraper can present a not expected behavior if has hosted in another port.
+:::
+
 #### Make necessary changes to the DocSearch Scraper config file
 
 After starting with one of the templates, you will want to change a few fields in the configuration:
@@ -108,15 +117,6 @@ The easiest way to run the scraper is using Docker.
     ```bash
     docker run -it --env-file=/path/to/your/.env -e "CONFIG=$(cat config.json | jq -r tostring)" typesense/docsearch-scraper:0.9.1
     ```
-
-  :::tip
-  If you are running Typesense on `localhost` and you're using Docker to run the scraper, you will need to change some things in your `config.json` file.
-
-  On `start_urls` and `sitemap_urls`, you will need to target the `host.docker.internal` URL, to ensure that will find the right site in your host machine, instead
-  of trying to find it inside the container.
-
-  You will need to run your site at port `:80`, because the scraper can present a not expected behavior if has hosted in another port.
-  :::
 
 This will scrape your documentation site and index it into Typesense.
 


### PR DESCRIPTION
## Change Summary

Add a `tip` block related to how to customize your `config.json` file to be right handled by the DocSearch scraper.

It's related to this issue: https://github.com/typesense/typesense-docsearch-scraper/issues/49

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
