### PR TITLE
Updated supabase-full-text-search.md | updated pg_net reference

### DIFF
--- a/docs-site/content/guide/supabase-full-text-search.md
+++ b/docs-site/content/guide/supabase-full-text-search.md
@@ -238,10 +238,9 @@ When the query completes, you can use the returned _request_id_ to find the resp
 
 ```sql
 SELECT
-    *,
-    (response).body::JSON AS body
-FROM
-    net._http_collect_response(<request_id>);
+  *
+FROM net._http_response
+WHERE id = <request_id>
 ```
 
 > NOTE: At the end of STEP 5.2, we will discuss how this table can be used to retry failed syncs.


### PR DESCRIPTION
Updated function signature to match current version of pg_net

## Change Summary
PG_NET no longer supports the  `net._http_collect_response(<request_id>);` function. Removed it


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
