### PR TITLE
Update reference to laravel documentation

### DIFF
--- a/docs-site/content/guide/reference-implementations/laravel-scout-integration.md
+++ b/docs-site/content/guide/reference-implementations/laravel-scout-integration.md
@@ -2,7 +2,7 @@
 
 Laravel supports a native integration with Typesense, via Laravel Scout. 
 
-Here's the official documentation on how to set up this integration: [https://laravel.com/docs/10.x/scout#typesense](https://laravel.com/docs/10.x/scout#typesense).  
+Here's the official documentation on how to set up this integration: [https://laravel.com/docs/scout#typesense](https://laravel.com/docs/scout#typesense).  
 
 Here's a demo Laravel app that shows you the Typesense Scout integration in action:
 


### PR DESCRIPTION
## Change Summary
Documentation link to Laravel is (slightly) outdated. 

Laravel released new current version. Leaving out the version from the url performs a redirect to current version which likely wont need updating

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
