### PR TITLE
Remove additional dependency when using Github actions for e2e tests.

### DIFF
--- a/docs-site/content/guide/github-actions.md
+++ b/docs-site/content/guide/github-actions.md
@@ -6,7 +6,40 @@ GitHub Actions provides powerful automation which enables you to setup your cont
 
 When using Typesense you might want to run end-to-end tests -- these are test that run with real instances of your application's dependencies and not against mocks. Running your tests against an actual Typesense instance increases the confidence in your code and the contract between your app and Typesense. Adding Typesense to a GitHub Action is pretty straightforward.
 
-You can configure the Typesense server in your workflow YAML file. Depending on your needs, you may configure it to run on a different port or you may make run your tests against a matrix of multiple Typesense versions.
+There is a GitHub Action providing a Typesense server. You can find it in the GitHub marketplace at [jirevwe/typesense-github-action](https://github.com/marketplace/actions/typesense-server-in-github-actions) and install it from there.
+
+You can configure the Typesense server in your workflow YAML file. Depending on your needs, you may configre it to run on a different port or you may make run your tests against a matrix of multiple Typesense versions.
+
+Here’s a sample configuration using the [jirevwe/typesense-github-action](https://github.com/marketplace/actions/typesense-server-in-github-actions) package to add Typesense to your GitHub Actions:
+
+```yaml
+name: Run tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        typesense-version: [0.22.0, 0.23.1]
+
+    steps:
+      - name: Start Typesense
+        uses: jirevwe/typesense-github-action@v1.0.1
+        with:
+          typesense-version: ${{ matrix.typesense-version }}
+          typesense-port: 20863
+
+      - name: Curl Typesense
+        run: sleep 10 && curl http://localhost:8108/health
+```
+
+This workflow setup runs your action's steps against each version of Typesense specified in the `typesense-version` list. This allows you run your tests against multiple versions of Typesense. One usecase of running your tests against multiple versions is if you want to be sure that updating your Typesense self-hosted or cloud version won't break your app's functionality.
+
+There's a full example of how this works [here](https://github.com/jirevwe/typesense-actions-demo).
+
+Or you want something direct, no additional Github actions package needed:
 
 ```yaml
 name: Run tests
@@ -43,8 +76,7 @@ jobs:
         run: sleep 1 && curl http://localhost:8108/health
 ```
 
-This workflow setup runs your action's steps against each version of Typesense specified in the `typesense-version` list. This allows you run your tests against multiple versions of Typesense. One usecase of running your tests against multiple versions is if you want to be sure that updating your Typesense self-hosted or cloud version won't break your app's functionality.
-
-There's a full example of how this works [here](https://github.com/jaeyson/ex_typesense/blob/main/.github/workflows/ci.yml).
+A full example file can be found [here](https://github.com/jaeyson/ex_typesense/blob/main/.github/workflows/ci.yml).
 
 And that's it! As we saw above, Typesense is easy to set up and simple to use. You can use it with your apps to create fast, typo-tolerant search interfaces. And with this package you can easily test your Typesense integration. If you face any difficulties with Typesense or would like to see any new features added, head over to our [GitHub repo](https://github.com/typesense/typesense) and create an issue.
+

--- a/docs-site/content/guide/github-actions.md
+++ b/docs-site/content/guide/github-actions.md
@@ -6,11 +6,7 @@ GitHub Actions provides powerful automation which enables you to setup your cont
 
 When using Typesense you might want to run end-to-end tests -- these are test that run with real instances of your application's dependencies and not against mocks. Running your tests against an actual Typesense instance increases the confidence in your code and the contract between your app and Typesense. Adding Typesense to a GitHub Action is pretty straightforward.
 
-There is a GitHub Action providing a Typesense server. You can find it in the GitHub marketplace at [jirevwe/typesense-github-action](https://github.com/marketplace/actions/typesense-server-in-github-actions) and install it from there.
-
-You can configure the Typesense server in your workflow YAML file. Depending on your needs, you may configre it to run on a different port or you may make run your tests against a matrix of multiple Typesense versions.
-
-Here’s a sample configuration using the [jirevwe/typesense-github-action](https://github.com/marketplace/actions/typesense-server-in-github-actions) package to add Typesense to your GitHub Actions:
+You can configure the Typesense server in your workflow YAML file. Depending on your needs, you may configure it to run on a different port or you may make run your tests against a matrix of multiple Typesense versions.
 
 ```yaml
 name: Run tests
@@ -22,21 +18,33 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        typesense-version: [0.22.0, 0.23.1]
+        # versions are wrapped in quotes to preserve the exact versions
+        # especially numbers that has "0" on right-most side (e.g. 26.0)
+        typesense-version: ['0.25.2', '26.0']
+        typesense-port: ['8108:8108']
+
+    services:
+      typesense:
+        image: typesense/typesense:${{ matrix.typesense-version }}
 
     steps:
       - name: Start Typesense
-        uses: jirevwe/typesense-github-action@v1.0.1
-        with:
-          typesense-version: ${{ matrix.typesense-version }}
-          typesense-port: 20863
+        run: |
+          docker run -d \
+          -p ${{ matrix.typesense-port }} \
+          --name typesense \
+          -v /tmp/typesense:/data \
+          typesense/typesense:${{ matrix.typesense-version}} \
+          --api-key=xyz \
+          --data-dir /data \
+          --enable-cors
 
       - name: Curl Typesense
-        run: sleep 10 && curl http://localhost:8108/health
+        run: sleep 1 && curl http://localhost:8108/health
 ```
 
 This workflow setup runs your action's steps against each version of Typesense specified in the `typesense-version` list. This allows you run your tests against multiple versions of Typesense. One usecase of running your tests against multiple versions is if you want to be sure that updating your Typesense self-hosted or cloud version won't break your app's functionality.
 
-There's a full example of how this works [here](https://github.com/jirevwe/typesense-actions-demo).
+There's a full example of how this works [here](https://github.com/jaeyson/ex_typesense/blob/main/.github/workflows/ci.yml).
 
 And that's it! As we saw above, Typesense is easy to set up and simple to use. You can use it with your apps to create fast, typo-tolerant search interfaces. And with this package you can easily test your Typesense integration. If you face any difficulties with Typesense or would like to see any new features added, head over to our [GitHub repo](https://github.com/typesense/typesense) and create an issue.

--- a/docs-site/content/guide/github-actions.md
+++ b/docs-site/content/guide/github-actions.md
@@ -8,7 +8,7 @@ When using Typesense you might want to run end-to-end tests -- these are test th
 
 There is a GitHub Action providing a Typesense server. You can find it in the GitHub marketplace at [jirevwe/typesense-github-action](https://github.com/marketplace/actions/typesense-server-in-github-actions) and install it from there.
 
-You can configure the Typesense server in your workflow YAML file. Depending on your needs, you may configre it to run on a different port or you may make run your tests against a matrix of multiple Typesense versions.
+You can configure the Typesense server in your workflow YAML file. Depending on your needs, you may configure it to run on a different port or you may make run your tests against a matrix of multiple Typesense versions.
 
 Here’s a sample configuration using the [jirevwe/typesense-github-action](https://github.com/marketplace/actions/typesense-server-in-github-actions) package to add Typesense to your GitHub Actions:
 


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Basically we can write e2e tests without relying on another Github actions package like [`jirevwe/typesense-github-action@v1.0.1`](https://github.com/marketplace/actions/typesense-server-in-github-actions). Just purely relying on containers.

- Proof of workflow action that passed the test: https://github.com/jaeyson/ex_typesense/actions/runs/9212348923/job/25343766747
- Link to the example file: https://github.com/jaeyson/ex_typesense/blob/main/.github/workflows/ci.yml

The main gist is to add a service container then `docker run...`

```yaml
...
    strategy:
      matrix:
        typesense-version: ['0.25.2', '26.0']
        typesense-port: ['8108:8108']
...
    services:
      typesense:
        image: typesense/typesense:${{ matrix.typesense-version }}
        
    steps:
      - name: Checkout repo
        uses: actions/checkout@v4

      - name: Start Typesense
        run: |
          docker run -d \
          -p ${{ matrix.typesense-port }} \
          --name typesense \
          -v /tmp/typesense:/data \
          typesense/typesense:${{ matrix.typesense-version}} \
          --api-key=xyz \
          --data-dir /data \
          --enable-cors
...
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
