### PR TITLE
docs(collection): add warning about concurrent alter operations in v26.0

### DIFF
--- a/docs-site/content/26.0/api/collections.md
+++ b/docs-site/content/26.0/api/collections.md
@@ -1109,9 +1109,10 @@ Alternatively, you can also use the [alias feature](#using-an-alias) to do zero 
 :::
 
 :::warning
-Starting with `v26.0`, only one alter operation can be in progress at a time for a given cluster.
+Only one alter operation can be in progress at a time for a given cluster.
 
-This was enforced because clients were timing out on alter operations and retrying.
+Since the alter operation can take a long time, this ensures that a client with a short default time-out does 
+not end up retrying the same alter request.
 :::
 
 The update operation consists of an initial validation step where the records on-disk are assessed to ensure 

--- a/docs-site/content/26.0/api/collections.md
+++ b/docs-site/content/26.0/api/collections.md
@@ -1108,6 +1108,12 @@ Reads will be serviced as usual, without blocking.
 Alternatively, you can also use the [alias feature](#using-an-alias) to do zero downtime schema changes.
 :::
 
+:::warning
+Starting with `v26.0`, only one alter operation can be in progress at a time for a given cluster.
+
+This was enforced because clients were timing out on alter operations and retrying.
+:::
+
 The update operation consists of an initial validation step where the records on-disk are assessed to ensure 
 that they are compatible with the proposed schema change. For example, let's say there is a `string` field `A` which 
 is already present in the documents on-disk but is not part of the schema. If you try to update the collection 


### PR DESCRIPTION
## Change Summary
This change adds an important warning to the collections API documentation for Typesense v26.0. It informs users about a new restriction on concurrent alter operations, which was implemented to address client timeout issues. 

- Added a warning block to highlight a new limitation in v26.0
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
