### PR TITLE
Update Laravel docs links to the current version (v11)

### DIFF
--- a/docs-site/content/0.25.2/api/api-clients.md
+++ b/docs-site/content/0.25.2/api/api-clients.md
@@ -129,7 +129,7 @@ We also have the following framework integrations:
 
 - [Firebase](https://github.com/typesense/firestore-typesense-search)
 - [AWS Amplify](https://github.com/olliethedev/amplify-graphql-typesense-transformer)
-- [Laravel](https://laravel.com/docs/10.x/scout#typesense)
+- [Laravel](https://laravel.com/docs/11.x/scout#typesense)
 - [Symfony](https://github.com/acseo/TypesenseBundle)
 - [Gatsby](https://www.gatsbyjs.com/plugins/gatsby-plugin-typesense/)
 - [SEAL](https://github.com/schranz-search/schranz-search) provides integrations of Typesense in Laravel, Symfony, Spiral, Yii and Laminas Mezzio PHP Framework

--- a/docs-site/content/26.0/api/api-clients.md
+++ b/docs-site/content/26.0/api/api-clients.md
@@ -129,7 +129,7 @@ We also have the following framework integrations:
 
 - [Firebase](https://github.com/typesense/firestore-typesense-search)
 - [AWS Amplify](https://github.com/olliethedev/amplify-graphql-typesense-transformer)
-- [Laravel](https://laravel.com/docs/10.x/scout#typesense)
+- [Laravel](https://laravel.com/docs/11.x/scout#typesense)
 - [Symfony](https://github.com/acseo/TypesenseBundle)
 - [Gatsby](https://www.gatsbyjs.com/plugins/gatsby-plugin-typesense/)
 - [SEAL](https://github.com/schranz-search/schranz-search) provides integrations of Typesense in Laravel, Symfony, Spiral, Yii and Laminas Mezzio PHP Framework

--- a/docs-site/content/guide/reference-implementations/laravel-scout-integration.md
+++ b/docs-site/content/guide/reference-implementations/laravel-scout-integration.md
@@ -12,4 +12,4 @@ Here's a demo Laravel app that shows you the Typesense Scout integration in acti
 
 - [Here's](https://github.com/typesense/user-admin-search-laravel-demo/blob/bf8dc96074cf29f2862b007c5849c7e51daf623e/config/scout.php#L145-L207) how to configure the Scout integration.
 - [Here's](https://github.com/typesense/user-admin-search-laravel-demo/blob/bf8dc96074cf29f2862b007c5849c7e51daf623e/app/Models/User.php#L48-L59) how to configure the model.
-- [Here's](https://laravel.com/docs/10.x/scout#typesense) the official Laravel Scout documentation on how to set up the Typesense integration.
+- [Here's](https://laravel.com/docs/11.x/scout#typesense) the official Laravel Scout documentation on how to set up the Typesense integration.

--- a/typesense.org/components/Footer.vue
+++ b/typesense.org/components/Footer.vue
@@ -136,7 +136,7 @@
             <li class="nav-item">
               <a
                 class="nav-link p-0"
-                href="https://laravel.com/docs/10.x/scout#typesense"
+                href="https://laravel.com/docs/11.x/scout#typesense"
                 >Laravel Scout Driver
               </a>
             </li>

--- a/typesense.org/components/Home/SectionAPILibraries.vue
+++ b/typesense.org/components/Home/SectionAPILibraries.vue
@@ -180,7 +180,7 @@
               />
             </a>
             <a
-              href="https://laravel.com/docs/10.x/scout#typesense"
+              href="https://laravel.com/docs/11.x/scout#typesense"
               target="_blank"
             >
               <img


### PR DESCRIPTION
## Change Summary
The current version of the Laravel docs are for v11. Update the links to the Typesense section there.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
