### PR TITLE
Update the comparison table to make it fair

### DIFF
--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -150,6 +150,7 @@
                   <td>✅<br /><br />RAFT-based multi-node clustering</td>
                   <td>✅<br /><br />RAFT-based multi-node clustering</td>
                   <td>✅<br /><br />Active-passive replication</td>
+                  <td>❌</td>
                 </tr>
                 <tr>
                   <td class="font-weight-bold">GPU Acceleration Support</td>

--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -150,11 +150,6 @@
                   <td>✅<br /><br />RAFT-based multi-node clustering</td>
                   <td>✅<br /><br />RAFT-based multi-node clustering</td>
                   <td>✅<br /><br />Active-passive replication</td>
-                  <td class="text-danger">
-                    ❌<br /><br />Only supports a single-node setup, which
-                    creates a single point of failure and so is not fault
-                    tolerant / production-ready.
-                  </td>
                 </tr>
                 <tr>
                   <td class="font-weight-bold">GPU Acceleration Support</td>


### PR DESCRIPTION
As stated [in this comment](https://github.com/meilisearch/meilisearch/issues/1148#issuecomment-2307206979), it would be preferable to be fair when comparing against competitors.

## Change Summary
Remove a false claim that Meilisearch is not suited for production. The Meilisearch company runs thousands of instances with an availability of more than 98.9% and 99.9% for big customers.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
