### PR TITLE
docs(collections): add clarification on field removal by update

### DIFF
--- a/docs-site/content/26.0/api/collections.md
+++ b/docs-site/content/26.0/api/collections.md
@@ -1098,7 +1098,9 @@ curl "http://localhost:8108/collections/companies" \
 Dropping a field affects only the schema and the in-memory index; 
 it does not remove the data associated with that field from the existing documents stored on disk.
 In Typesense, documents can contain additional fields not explicitly defined in the schema.
-To permanently remove a field and its data from a document, you must update the document directly.
+
+To permanently remove a field and its data from a document, you must update the document directly, by passing `null`
+to the field you want to remove.
 :::
 
 **Definition**

--- a/docs-site/content/26.0/api/collections.md
+++ b/docs-site/content/26.0/api/collections.md
@@ -1094,6 +1094,13 @@ curl "http://localhost:8108/collections/companies" \
   </template>
 </Tabs>
 
+:::tip
+Dropping a field affects only the schema and the in-memory index; 
+it does not remove the data associated with that field from the existing documents stored on disk.
+In Typesense, documents can contain additional fields not explicitly defined in the schema.
+To permanently remove a field and its data from a document, you must update the document directly.
+:::
+
 **Definition**
 `PATCH ${TYPESENSE_HOST}/collections/:collection`
 


### PR DESCRIPTION
## Change Summary
The documentation now explicitly states that dropping a field only affects 
the schema and in-memory index, without deleting the field's data from existing 
documents stored on disk. Instructions to permanently remove field data have 
also been included.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
