### PR TITLE
docs(vector-search): add pagination guidance for vector search

### DIFF
--- a/docs-site/content/27.0/api/vector-search.md
+++ b/docs-site/content/27.0/api/vector-search.md
@@ -2357,29 +2357,6 @@ Since vector search queries tend to be large because of the large dimension of t
 using the `multi_search` end-point that sends the search parameters as a POST request body.
 :::
 
-:::tip
-To paginate through the results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
-```shell{11,13,14}
-curl 'http://localhost:8108/multi_search' \
-  -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
-  -X POST \
-  -d '{
-    "searches": [
-      {
-        "q": "device to type things on",
-        "query_by": "embedding",
-        "collection": "products",
-        "prefix": "false",
-        "vector_query": "embedding([], k: 200)",
-        "exclude_fields": "embedding",
-        "per_page": 10,
-        "page": 1
-      }
-    ]
-  }'
-```
-:::
-
 :::warning Network Bandwidth Optimization
 By default Typesense returns all fields in the document as part of the search API response.
 
@@ -2427,6 +2404,33 @@ To prevent this, you want to add `exclude_fields: "your_embedding_field_name"` a
 
   </template>
 </Tabs>
+
+### Pagination
+
+To paginate through the vector search (or semantic or hybrid search) results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
+
+```shell{11,12,13}
+curl 'http://localhost:8108/multi_search' \
+  -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+  -X POST \
+  -d '{
+    "searches": [
+      {
+        "q": "device to type things on",
+        "query_by": "embedding",
+        "collection": "products",
+        "exclude_fields": "embedding",
+        "vector_query": "embedding([], k: 200)",
+        "per_page": 10,
+        "page": 1
+      }
+    ]
+  }'
+```
+
+This will ground the vector search to fetch the closest 200 items, and then paginate within that result-set, fetching 10 results per page. You'd then increment `page` to fetch additional pages of results.
+
+We do this because, with vector search, every item in the dataset is technically a "match" to some level of closeness. So we have to limit the upper limit of closeness either using a quantity value using the `k` parameter as described above, and/or using the [`distance_threshold`](#distance-threshold) parameter of `vector_query`. 
 
 ## Querying for similar documents
 

--- a/docs-site/content/27.0/api/vector-search.md
+++ b/docs-site/content/27.0/api/vector-search.md
@@ -2190,6 +2190,8 @@ The text used to generate embeddings for the `embedding` field will be `passage:
 
 Once you've indexed your embeddings in a vector field, you can now search for documents that are "closest" to a given query vector. 
 
+#### Pagination
+
 To control the number of documents that are returned, you can either use the `per_page` pagination parameter or the `k` parameter within the vector query.
 
 <Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart','Java','Shell']">

--- a/docs-site/content/27.0/api/vector-search.md
+++ b/docs-site/content/27.0/api/vector-search.md
@@ -2190,8 +2190,6 @@ The text used to generate embeddings for the `embedding` field will be `passage:
 
 Once you've indexed your embeddings in a vector field, you can now search for documents that are "closest" to a given query vector. 
 
-#### Pagination
-
 To control the number of documents that are returned, you can either use the `per_page` pagination parameter or the `k` parameter within the vector query.
 
 <Tabs :tabs="['JavaScript','PHP','Python','Ruby', 'Dart','Java','Shell']">
@@ -2357,6 +2355,29 @@ The hits are automatically sorted in ascending order of the `vector_distance`, i
 :::tip
 Since vector search queries tend to be large because of the large dimension of the query vector, we are
 using the `multi_search` end-point that sends the search parameters as a POST request body.
+:::
+
+:::tip
+To paginate through the results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
+```shell{11,13,14}
+curl 'http://localhost:8108/multi_search' \
+  -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+  -X POST \
+  -d '{
+    "searches": [
+      {
+        "q": "device to type things on",
+        "query_by": "embedding",
+        "collection": "products",
+        "prefix": "false",
+        "vector_query": "embedding([], k: 200)",
+        "exclude_fields": "embedding",
+        "per_page": 10,
+        "page": 1
+      }
+    ]
+  }'
+```
 :::
 
 :::warning Network Bandwidth Optimization

--- a/docs-site/content/guide/semantic-search.md
+++ b/docs-site/content/guide/semantic-search.md
@@ -467,10 +467,13 @@ curl 'http://localhost:8108/multi_search' \
   }'
 ```
 
-Optionally, use the `distance_threshold` parameter in `vector_query` to fine-tune semantic search results:
 * The `vector_query` parameter is set to `embedding([], k: 200)`, limiting the search to the 200 closest items.
 * `per_page` is set to 10, returning the top 10 results sorted by relevance.
 * You can then use the `page` parameter to paginate through the results.
+
+### Fine-tuning
+
+Optionally, you can use the `distance_threshold` parameter in `vector_query` to fine-tune semantic search results:
 
 ```shell{11}
 curl 'http://localhost:8108/multi_search' \

--- a/docs-site/content/guide/semantic-search.md
+++ b/docs-site/content/guide/semantic-search.md
@@ -442,6 +442,51 @@ Notice how searching for `Desktop copier` returns `Desktop` as a result which is
 }
 ```
 
+
+### Pagination
+
+For effective pagination with semantic or hybrid search, use the `k` parameter in `vector_search` to ground the search to a specific number of closest items:
+
+```shell{11}
+curl 'http://localhost:8108/multi_search' \
+  -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+  -X POST \
+  -d '{
+    "searches": [
+      {
+        "q": "device to type things on",
+        "query_by": "embedding",
+        "collection": "products",
+        "prefix": "false",
+        "vector_query": "embedding([], k: 200)",
+        "exclude_fields": "embedding",
+      }
+    ]
+  }'
+```
+
+Optionally, use the `distance_threshold` parameter in `vector_query` to fine-tune semantic search results:
+
+```shell{11}
+curl 'http://localhost:8108/multi_search' \
+  -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+  -X POST \
+  -d '{
+    "searches": [
+      {
+        "q": "device to type things on",
+        "query_by": "embedding",
+        "collection": "products",
+        "prefix": "false",
+        "vector_query": "embedding([], k: 200, distance_threshold: 1.0)",
+        "exclude_fields": "embedding",
+      }
+    ]
+  }'
+```
+
+For more details on the `vector_query` parameter and its options, please refer to the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/vector-search.html#nearest-neighbor-vector-search`">API documentation</RouterLink> for Vector Search.
+
 ## Live Demo
 
 [Here's](https://hn-comments-search.typesense.org) a live demo that shows you how to implement Semantic Search and Hybrid Search.

--- a/docs-site/content/guide/semantic-search.md
+++ b/docs-site/content/guide/semantic-search.md
@@ -447,7 +447,7 @@ Notice how searching for `Desktop copier` returns `Desktop` as a result which is
 
 For effective pagination with semantic or hybrid search, use the `k` parameter in `vector_search` to ground the search to a specific number of closest items:
 
-```shell{11}
+```shell{11,13,14}
 curl 'http://localhost:8108/multi_search' \
   -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
   -X POST \
@@ -460,12 +460,17 @@ curl 'http://localhost:8108/multi_search' \
         "prefix": "false",
         "vector_query": "embedding([], k: 200)",
         "exclude_fields": "embedding",
+        "per_page": 10,
+        "page": 1
       }
     ]
   }'
 ```
 
 Optionally, use the `distance_threshold` parameter in `vector_query` to fine-tune semantic search results:
+* The `vector_query` parameter is set to `embedding([], k: 200)`, limiting the search to the 200 closest items.
+* `per_page` is set to 10, returning the top 10 results sorted by relevance.
+* You can then use the `page` parameter to paginate through the results.
 
 ```shell{11}
 curl 'http://localhost:8108/multi_search' \

--- a/docs-site/content/guide/semantic-search.md
+++ b/docs-site/content/guide/semantic-search.md
@@ -467,11 +467,9 @@ curl 'http://localhost:8108/multi_search' \
   }'
 ```
 
-* The `vector_query` parameter is set to `embedding([], k: 200)`, limiting the search to the 200 closest items.
-* `per_page` is set to 10, returning the top 10 results sorted by relevance.
+* The `vector_query` parameter is set to `embedding([], k: 200)`, limiting the vector search to the 200 nearest-neighbor items.
+* `per_page` is set to `10`, returning the top 10 results sorted by relevance.
 * You can then use the `page` parameter to paginate through the results.
-
-### Fine-tuning
 
 Optionally, you can use the `distance_threshold` parameter in `vector_query` to fine-tune semantic search results:
 


### PR DESCRIPTION
## Change Summary
- Introduce `k` parameter usage in vector queries for pagination
- Demonstrate `distance_threshold` parameter for result tuning
- Include code examples for both parameters in curl requests
- Guide readers of guide page to API documentation by a link

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
