### PR TITLE
fix: typo on grouping parameter link

### DIFF
--- a/docs-site/content/26.0/api/search.md
+++ b/docs-site/content/26.0/api/search.md
@@ -673,7 +673,7 @@ You can also sort the results by the sizes of the groups by using `_group_found`
 }
 ```
 
-You'll find detailed documentation for these grouping parameters in the [Groping Parameters](#grouping-parameters) table above.
+You'll find detailed documentation for these grouping parameters in the [Grouping Parameters](#grouping-parameters) table above.
 
 ## Pagination
 

--- a/docs-site/content/27.0/api/search.md
+++ b/docs-site/content/27.0/api/search.md
@@ -680,7 +680,7 @@ You can also sort the results by the sizes of the groups by using `_group_found`
 }
 ```
 
-You'll find detailed documentation for these grouping parameters in the [Groping Parameters](#grouping-parameters) table above.
+You'll find detailed documentation for these grouping parameters in the [Grouping Parameters](#grouping-parameters) table above.
 
 ## Pagination
 


### PR DESCRIPTION
## Change Summary
Fixed a typo from `groping` to `grouping`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
