### PR TITLE
docs(server-config): add analytics-minute-rate-limit server parameter

### DIFF
--- a/docs-site/content/27.1/api/server-configuration.md
+++ b/docs-site/content/27.1/api/server-configuration.md
@@ -35,11 +35,12 @@ Command line arguments can be passed to the server as `--parameter=value`.
 
 ### Analytics
 
-| Parameter                    | Required | Description                                                                                                                          |
-|------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `--enable-search-analytics`  | false    | Allow search queries to be aggregated for query analytics. Default: `false`                                                          |
-| `--analytics-dir`            | false    | Directory for Typesense to store analytics data.                                                                                     |
-| `--analytics-flush-interval` | false    | Interval (in seconds) that determines how often the search query aggregations are persisted to storage. Default: `3600` (every hour) |
+| Parameter                       | Required | Description                                                                                                                          |
+|---------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `--enable-search-analytics`     | false    | Allow search queries to be aggregated for query analytics. Default: `false`                                                          |
+| `--analytics-dir`               | false    | Directory for Typesense to store analytics data.                                                                                     |
+| `--analytics-flush-interval`    | false    | Interval (in seconds) that determines how often the search query aggregations are persisted to storage. Default: `3600` (every hour) |
+| `--analytics-minute-rate-limit` | false    | Maximum number of analytics events that can be sent per minute. Default: `5`                                                         |
 
 ### Logging
 


### PR DESCRIPTION
## Change Summary
- Document new server parameter for controlling the rate limit of analytics events. This parameter allows users to adjust the maximum number of events that can be sent per minute, addressing issues with event rate limiting in high-traffic scenarios.

Resolves https://github.com/typesense/typesense/issues/1980

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
