### PR TITLE
docs(keys): add tables for analytic actions for api keys

### DIFF
--- a/docs-site/content/27.1/api/api-keys.md
+++ b/docs-site/content/27.1/api/api-keys.md
@@ -359,6 +359,32 @@ In general, you want to use the format `resource:verb` pattern to indicate an ac
 | `keys:delete` | Allows the deletion of API keys.               |
 | `keys:*`      | Allows all API Key related operations.         |
 
+#### Analytics actions
+
+| Action             | Description                                                                             |
+|:-------------------|:----------------------------------------------------------------------------------------|
+| `analytics:list`   | Allows all analytics rules to be fetched.                                               |
+| `analytics:get`    | Allows for a single analytics rule to be fetched.                                       |
+| `analytics:create` | Allows the creation of analytics rules and events.                                      |
+| `analytics:delete` | Allows the deletion of analytics rules and events.                                      |
+| `analytics:*`      | Allows all analytics rules and events related operations.                               |
+
+##### Analytics Rules actions
+
+| Action             | Description                                                                        |
+|:-------------------|:-----------------------------------------------------------------------------------|
+| `analytics/rules:list`   | Allows all analytics rules to be fetched.                                    |
+| `analytics/rules:get`    | Allows for a single analytics rule to be fetched.                            |
+| `analytics/rules:create` | Allows the creation of analytics rules.                                      |
+| `analytics/rules:delete` | Allows the deletion of analytics rules.                                      |
+| `analytics/rules:*`      | Allows all analytics rules related operations.                               |
+
+##### Analytics Events actions
+
+| Action                    | Description                                                                        |
+|:--------------------------|:-----------------------------------------------------------------------------------|
+| `analytics/events:create` | Allows the creation of analytics events.                                           |
+
 #### Misc actions
 
 | Action               | Description                                       |


### PR DESCRIPTION
## Change Summary
Add three simple tables on the API Key documentation for documenting all available actions  for analytics, analytics rules, and analytics events.

Documentation updates:

* [`docs-site/content/27.1/api/api-keys.md`](diffhunk://#diff-a69f54deb53683cc23f5a853943ed632f97a58e27116acd0f889d7db64fb56deR362-R387): Added sections for `Analytics actions`, `Analytics Rules actions`, and `Analytics Events actions` with corresponding permissions and descriptions.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
