### PR TITLE
Fix vector query syntax in documentation

### DIFF
--- a/docs-site/content/27.0/api/vector-search.md
+++ b/docs-site/content/27.0/api/vector-search.md
@@ -2407,7 +2407,7 @@ To prevent this, you want to add `exclude_fields: "your_embedding_field_name"` a
 
 ### Pagination
 
-To paginate through the vector search (or semantic or hybrid search) results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
+To paginate through the vector search (or semantic or hybrid search) results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding:([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
 
 ```shell{11,12,13}
 curl 'http://localhost:8108/multi_search' \
@@ -2420,7 +2420,7 @@ curl 'http://localhost:8108/multi_search' \
         "query_by": "embedding",
         "collection": "products",
         "exclude_fields": "embedding",
-        "vector_query": "embedding([], k: 200)",
+        "vector_query": "embedding:([], k: 200)",
         "per_page": 10,
         "page": 1
       }

--- a/docs-site/content/27.1/api/vector-search.md
+++ b/docs-site/content/27.1/api/vector-search.md
@@ -2407,7 +2407,7 @@ To prevent this, you want to add `exclude_fields: "your_embedding_field_name"` a
 
 ### Pagination
 
-To paginate through the vector search (or semantic or hybrid search) results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
+To paginate through the vector search (or semantic or hybrid search) results, use the `k` parameter in `vector_search` to limit results (e.g., `embedding:([], k: 200)`), set `per_page` for the number of results per page, and use the `page` parameter to navigate through paginated results:
 
 ```shell{11,12,13}
 curl 'http://localhost:8108/multi_search' \
@@ -2420,7 +2420,7 @@ curl 'http://localhost:8108/multi_search' \
         "query_by": "embedding",
         "collection": "products",
         "exclude_fields": "embedding",
-        "vector_query": "embedding([], k: 200)",
+        "vector_query": "embedding:([], k: 200)",
         "per_page": 10,
         "page": 1
       }

--- a/docs-site/content/guide/semantic-search.md
+++ b/docs-site/content/guide/semantic-search.md
@@ -458,7 +458,7 @@ curl 'http://localhost:8108/multi_search' \
         "query_by": "embedding",
         "collection": "products",
         "prefix": "false",
-        "vector_query": "embedding([], k: 200)",
+        "vector_query": "embedding:([], k: 200)",
         "exclude_fields": "embedding",
         "per_page": 10,
         "page": 1
@@ -467,7 +467,7 @@ curl 'http://localhost:8108/multi_search' \
   }'
 ```
 
-* The `vector_query` parameter is set to `embedding([], k: 200)`, limiting the vector search to the 200 nearest-neighbor items.
+* The `vector_query` parameter is set to `embedding:([], k: 200)`, limiting the vector search to the 200 nearest-neighbor items.
 * `per_page` is set to `10`, returning the top 10 results sorted by relevance.
 * You can then use the `page` parameter to paginate through the results.
 
@@ -484,7 +484,7 @@ curl 'http://localhost:8108/multi_search' \
         "query_by": "embedding",
         "collection": "products",
         "prefix": "false",
-        "vector_query": "embedding([], k: 200, distance_threshold: 1.0)",
+        "vector_query": "embedding:([], k: 200, distance_threshold: 1.0)",
         "exclude_fields": "embedding",
       }
     ]


### PR DESCRIPTION
## Change Summary

# What is this?
A documentation fix that corrects the vector query syntax examples throughout our guides. The correct syntax requires a colon (`:`) after the field name in vector queries, ensuring users can properly implement vector search functionality in their applications.

# Changes

## Documentation Updates:
1. **In `docs-site/content/27.0/api/vector-search.md` and `27.1/api/vector-search.md`**:
    - Updated vector query syntax from `embedding([], k: 200)` to `embedding:([], k: 200)`
    - Fixed examples in pagination section

2. **In `docs-site/content/guide/semantic-search.md`**:
    - Updated vector query examples to use correct syntax
    - Fixed vector query syntax in both basic and threshold examples
    - Examples updated:
      - Basic vector query: `embedding:([], k: 200)`
      - Vector query with threshold: `embedding:([], k: 200, distance_threshold: 1.0)`

# Context
The fix addresses issue https://github.com/typesense/typesense/issues/2054  where user @jc-skurman reported syntax errors when following our semantic search guide. The missing colon in the vector query syntax was causing the API to return "Malformed vector query string" errors. These documentation updates ensure users can successfully implement vector search by following our examples.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
