### PR TITLE
OpenAI compatible endpoints require model name starts with `openai`.

### DIFF
--- a/docs-site/content/27.1/api/vector-search.md
+++ b/docs-site/content/27.1/api/vector-search.md
@@ -51,7 +51,7 @@ Here is one (of many possible) practical applications of vector search - a "Find
 
 Here are two articles that talk about embeddings in more detail:
 
-- [What Are Word and Sentence Embeddings?](https://txt.cohere.ai/sentence-word-embeddings/)
+- [What Are Word and Sentence Embeddings?](https://txt.cohere.ai/sentence-word-embeddings/)f
 - [Getting Started With Embeddings](https://huggingface.co/blog/getting-started-with-embeddings)
 
 Let's now discuss how to do index and search embeddings in Typesense.
@@ -1163,6 +1163,8 @@ curl 'http://localhost:8108/collections' \
 </Tabs>
 
 When you create the collection above, Typesense will call the OpenAI-API compatible API server running behind `https://your-custom-openai-compatible-api.domain.com` to create embeddings from the `product_name` field and store them in the `embedding` field every time you index a document.
+
+The `model_name` within `model_config` *must* begin with `openai`.
 
 The custom API server behind the specified URL should provide the following endpoint:
 

--- a/docs-site/content/27.1/api/vector-search.md
+++ b/docs-site/content/27.1/api/vector-search.md
@@ -51,7 +51,7 @@ Here is one (of many possible) practical applications of vector search - a "Find
 
 Here are two articles that talk about embeddings in more detail:
 
-- [What Are Word and Sentence Embeddings?](https://txt.cohere.ai/sentence-word-embeddings/)f
+- [What Are Word and Sentence Embeddings?](https://txt.cohere.ai/sentence-word-embeddings/)
 - [Getting Started With Embeddings](https://huggingface.co/blog/getting-started-with-embeddings)
 
 Let's now discuss how to do index and search embeddings in Typesense.


### PR DESCRIPTION
## Change Summary

As visible [here](https://github.com/typesense/typesense/blob/8cdd3101ecd31da80acf388bc72005be60ec4512/src/embedder_manager.cpp#L532) in `embedder_manager.cpp`, remote endpoints are expected to have a model name which starts with one of  `openai/`, `google/` or  `gcp/`.

This prefix [is removed](https://github.com/typesense/typesense/blob/98dfb5b686b7d46620f35af36986698563bd908f/src/text_embedder_remote.cpp#L102) slightly later on in the execution of the program when running an OpenAI compatible endpoint.

The documentation doesn't make it clear that OpenAI-compatible endpoints have to start with "openai" in the model name, so, I've added that fact in.



## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
