### PR TITLE
fix(stemming): fix stemming endpoint paths in examples

### DIFF
--- a/docs-site/content/28.0/api/stemming.md
+++ b/docs-site/content/28.0/api/stemming.md
@@ -65,7 +65,7 @@ Then upload it using the stemming dictionary API:
   <template v-slot:Shell>
 
 ```bash
-curl "http://localhost:8108/stemming/dictionary/import?id=irregular-plurals" \
+curl "http://localhost:8108/stemming/dictionaries/import?id=irregular-plurals" \
 -X POST \
 -H "Content-Type: application/json" \
 -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
@@ -128,7 +128,7 @@ You can use both basic stemming (`"stem": true`) and dictionary stemming (`"stem
 
 ```bash
 curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
-"http://localhost:8108/stemming/dictionary/irregular-plurals"
+"http://localhost:8108/stemming/dictionaries/irregular-plurals"
 ```
 
   </template>


### PR DESCRIPTION
## Change Summary
This pull request includes changes to the `docs-site/content/28.0/api/stemming.md` file to correct the API endpoint for stemming dictionaries.

Documentation updates:

* [`docs-site/content/28.0/api/stemming.md`](diffhunk://#diff-3e4dfadbc24bb85890c32599a364e55f90e518dddf5a685db8f2b6845827054cL68-R68): Changed the endpoint from `/stemming/dictionary/` to `/stemming/dictionaries/` in two instances to reflect the correct API usage

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
