### PR TITLE
docs(filtering-guide): fix range operator having three dots

### DIFF
--- a/docs-site/content/guide/tips-for-filtering.md
+++ b/docs-site/content/guide/tips-for-filtering.md
@@ -84,7 +84,7 @@ Commas act as OR operators, allowing flexible condition combinations.
 The range operator can be used with multiple array elements, creating a logical OR between ranges or values:
 
 ```shell
-price:[100...200, 15...50, 800]
+price:[100..200, 15..50, 800]
 ```
 
 This matches items with prices:
@@ -187,7 +187,7 @@ Would in turn return this document.
 Subsequently, you can also use array operators:
 
 ```shell
-deparment_prices:[20...80]
+deparment_prices:[20..80]
 ```
 
 ## Escaping special characters


### PR DESCRIPTION
## Change Summary

This pull request includes updates to the documentation for filtering tips to correct the usage of range operators.

Documentation updates:

* [`docs-site/content/guide/tips-for-filtering.md`](diffhunk://#diff-5c578d5a346f721251aafd8ec841a843a5428e639aebf0c99afda299b0e78e0dL87-R87): Changed the range operator from `...` to `..` in the `price` filter example to correctly reflect the intended range syntax.
* [`docs-site/content/guide/tips-for-filtering.md`](diffhunk://#diff-5c578d5a346f721251aafd8ec841a843a5428e639aebf0c99afda299b0e78e0dL190-R190): Updated the `deparment_prices` filter example to use the correct range operator `..`.
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
