### PR TITLE
fix(docs): unify analytics rule names across code examples

### DIFF
--- a/docs-site/content/28.0/api/analytics-query-suggestions.md
+++ b/docs-site/content/28.0/api/analytics-query-suggestions.md
@@ -140,7 +140,7 @@ client.analytics.rules().upsert(ruleName, ruleConfiguration)
   <template v-slot:Ruby>
 
 ```rb
-rule_name = 'popular_queries'
+rule_name = 'product_queries_aggregation'
 rule_configuration = {
   'type' => 'popular_queries',
   'params' => {
@@ -426,7 +426,7 @@ aggregated in `no_hits_queries` collection.
   <template v-slot:JavaScript>
 
 ```js
-let ruleName =  'product_queries_aggregation'
+let ruleName =  'product_no_hits'
 let ruleConfiguration = {
   "type": "nohits_queries",
   "params": {
@@ -448,7 +448,7 @@ client.analytics.rules().upsert(ruleName, ruleConfiguration)
   <template v-slot:Ruby>
 
 ```rb
-rule_name = 'popular_queries'
+rule_name = 'product_no_hits'
 rule_configuration = {
   'type' => 'nohits_queries',
   'params' => {
@@ -521,9 +521,8 @@ Let's define a `counter` analytics rule that will increment this field whenever 
   <template v-slot:JavaScript>
 
 ```js
-let ruleName =  'product_queries_aggregation'
+let ruleName =  'product_clicks'
 let ruleConfiguration = {
-    "name": "products_popularity",
     "type": "counter",
     "params": {
         "source": {
@@ -547,9 +546,8 @@ client.analytics.rules().upsert(ruleName, ruleConfiguration)
 <template v-slot:Ruby>
 
 ```rb
-rule_name = 'popular_queries'
+rule_name = 'product_clicks'
 rule_configuration = {
-    "name" => "products_popularity",
     "type" => "counter",
     "params" => {
         "source": {
@@ -578,7 +576,7 @@ curl -k "http://localhost:8108/analytics/rules" \
       -H "Content-Type: application/json" \
       -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
       -d '{
-        "name": "products_popularity",
+        "name": "product_clicks",
         "type": "counter",
         "params": {
             "source": {


### PR DESCRIPTION
### TLDR
Addresses #291 
## Change Summary
**Changes to rule names and configurations:**

* Updated Ruby example rule name from `'popular_queries'` to `'product_queries_aggregation'` and `'product_no_hits'` (`client.analytics.rules().upsert(ruleName, ruleConfiguration)`) 
* Updated JavaScript example rule name from `'product_queries_aggregation'` to `'product_no_hits'` (`aggregated in 'no_hits_queries' collection.`).
* Updated JavaScript example rule name from `'product_queries_aggregation'` to `'product_clicks'` (`Let's define a 'counter' analytics rule that will increment this field whenever`).
* Updated Ruby example rule name from `'popular_queries'` to `'product_clicks'` (`client.analytics.rules().upsert(ruleName, ruleConfiguration)`).
* Updated cURL example rule name from `'products_popularity'` to `'product_clicks'` (`curl -k "http://localhost:8108/analytics/rules" This pull request includes updates to the `docs-site/content/28.0/api/analytics-query-suggestions.md` file to change the names of various analytic rules. The changes include renaming rule names and their configurations to better reflect their purposes.

Changes to rule names and configurations:

* Updated Ruby example rule name from `'popular_queries'` to `'product_queries_aggregation'` and `'product_no_hits'` (`client.analytics.rules().upsert(ruleName, ruleConfiguration)`) [[1]](diffhunk://#diff-71b18caaf60f0a8198466f4b374231e5cdc2efb2c3f464f4efd9f1d1d9389a94L143-R143) [[2]](diffhunk://#diff-71b18caaf60f0a8198466f4b374231e5cdc2efb2c3f464f4efd9f1d1d9389a94L451-R451).
* Updated JavaScript example rule name from `'product_queries_aggregation'` to `'product_no_hits'` (`aggregated in 'no_hits_queries' collection.`).
* Updated JavaScript example rule name from `'product_queries_aggregation'` to `'product_clicks'` (`Let's define a 'counter' analytics rule that will increment this field whenever`).
* Updated Ruby example rule name from `'popular_queries'` to `'product_clicks'` (`client.analytics.rules().upsert(ruleName, ruleConfiguration)`).


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
