### PR TITLE
fix(laravel-guide): add warning for model imports on scout guide

### DIFF
--- a/docs-site/content/guide/laravel-full-text-search.md
+++ b/docs-site/content/guide/laravel-full-text-search.md
@@ -596,6 +596,10 @@ return [
 
 </Tabs>
 
+:::warning
+Don't forget to import your model a the top of the `config.php` file using `use App\Models\Game;`. This is essential for the `model-settings` to work.
+:::
+
 After setting up the Laravel Scout Driver, all subsequent model changes will be **automatically synced** with Typesense, using the [Model Observer](https://github.com/laravel/scout/blob/10.x/src/ModelObserver.php) provided by Laravel Scout. 
 
 To verify that it's working, let's create a new record in the `Games` table. We'll be using [Laravel Tinker](https://github.com/laravel/tinker), a REPL enabling us to write and execute PHP code interactively. You can run the following command to open Laravel Tinker:


### PR DESCRIPTION
## Change Summary
This pull request includes a small but important change to the `docs-site/content/guide/laravel-full-text-search.md` file. The change adds a warning to remind users to import their model at the top of the `config.php` file, which is essential for the `model-settings` to work.

Documentation update:

* [`docs-site/content/guide/laravel-full-text-search.md`](diffhunk://#diff-ae2706c19edacdf71bd9f872b705c1bb5e154d10f8092895df17b0f7e2e876b5R599-R602): Added a warning to import the model using `use App\Models\Game;` at the top of the `config.php` file.<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
