### PR TITLE
docs: add tip about embedding regeneration behavior

### DIFF
--- a/docs-site/content/28.0/api/vector-search.md
+++ b/docs-site/content/28.0/api/vector-search.md
@@ -395,6 +395,10 @@ To simplify the process of embedding generation, Typesense can automatically use
 
 When you do a search query on this automatically-generated vector field, your search query will be vectorized using the same model used for the field, which then allows you to do semantic search or combine keyword and semantic search to do hybrid search.
 
+:::tip Embedding Updates
+Embeddings are only regenerated when one or more fields specified in the `embed.from` configuration are updated. This helps avoid unnecessary embedding recreation and API calls when other fields in the document are modified.
+:::
+
 ### Creating an auto-embedding field
 
 To create a field that automatically embeds other string or string array fields, you need to set the `embed` property of the field.


### PR DESCRIPTION
## Change Summary
This pull request includes an update to the documentation related to vector search in the `docs-site/content/28.0/api/vector-search.md` file. The update adds a tip about embedding updates to clarify when embeddings are regenerated.

Documentation update:

* Added a tip to explain that embeddings are only regenerated when fields specified in the `embed.from` configuration are updated, which helps avoid unnecessary embedding recreation and API calls. (`docs-site/content/28.0/api/vector-search.md`)
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
