### PR TITLE
feat(docs): add async_reference option to joins documentation

### DIFF
--- a/docs-site/content/28.0/api/joins.md
+++ b/docs-site/content/28.0/api/joins.md
@@ -443,6 +443,26 @@ This will always return an array of objects for the fields of `books` collection
 ]
 ```
 
+## Asynchronous references
+
+You can use the `async_reference` option when creating reference fields. This allows documents to be indexed successfully even when the referenced document doesn't exist yet.
+
+```json
+{
+  "name": "orders",
+  "fields": [
+    {"name": "product_id", "type": "string", "reference": "products.product_id", "optional": true, "async_reference": true}
+  ]
+}
+```
+
+By setting `async_reference: true`, documents will be indexed without returning the error:
+```
+Reference document having '...' not found in the collection '...'.
+```
+
+The resolution of references will happen automatically when the referenced documents get indexed later. This is particularly useful in scenarios where you need to index documents in an order different from their dependency relationships.
+
 ## References inside an object
 
 Let's say there is an `object` field called `order` in a `orders` collection. We can make the order refer to a


### PR DESCRIPTION


## Change Summary
<!--- Described your changes here -->
This pull request includes an update to the documentation for the `joins` API. The change introduces the concept of asynchronous references, which allows documents to be indexed even if the referenced document does not yet exist.

Documentation update:

* [`docs-site/content/28.0/api/joins.md`](diffhunk://#diff-cc6885ad44ade85ad49c6e9e6e9ec675565ce1444ae89c181a01c8d449e0b877R446-R465): Added a section on asynchronous references, including an example JSON configuration and an explanation of how `async_reference` works to prevent indexing errors when referenced documents are not yet available.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
