### PR TITLE
fix: preserve current page path when switching versions

### DIFF
--- a/docs-site/content/.vuepress/components/VersionDropdown.vue
+++ b/docs-site/content/.vuepress/components/VersionDropdown.vue
@@ -67,7 +67,15 @@ export default {
       const normalizedPath = this.currentPath.replace('/api', '')
       const prefix = needsApiPrefix ? '/api' : ''
 
-      return `/${version}${prefix}${normalizedPath}${this.currentHash}`
+      const targetPath = `/${version}${prefix}${normalizedPath}`
+
+      const pageExists = this.$site.pages.some(page => page.path === targetPath ?? page.path === `${targetPath}/`)
+
+      if (!pageExists && normalizedPath !== '/') {
+        return `/${version}${needsApiPrefix ? '/api/' : '/'}`
+      }
+
+      return `${targetPath}${this.currentHash}`
     },
     switchVersion(event) {
       const newVersion = event.target.value

--- a/docs-site/content/.vuepress/components/VersionDropdown.vue
+++ b/docs-site/content/.vuepress/components/VersionDropdown.vue
@@ -14,7 +14,9 @@
       </option>
     </select>
     <div class="old-version-warning" v-show="showOldVersionWarning">
-      You are viewing docs for an old version. Switch to latest <RouterLink :to="`/${latestVersion}/`"> v{{ latestVersion }}</RouterLink>.
+      You are viewing docs for an old version. Switch to latest
+      <RouterLink :to="getVersionedPath(latestVersion)"> v{{ latestVersion }}</RouterLink
+      >.
     </div>
   </div>
 </template>
@@ -41,18 +43,40 @@ export default {
     },
     showOldVersionWarning() {
       return this.currentVersion && this.currentVersion !== '' && this.currentVersion !== this.latestVersion
-    }
+    },
+    currentPath() {
+      const fullPath = this.$route.path
+      const versionMatch = fullPath.match(new RegExp(`^\\/${this.currentVersion}(\\/.*)?$`))
+      return versionMatch && versionMatch[1] ? versionMatch[1] : '/'
+    },
+    currentHash() {
+      return this.$route.hash || ''
+    },
   },
   methods: {
+    getVersionedPath(version) {
+      const versionParts = version.split('.')
+      const majorVersion = parseInt(versionParts[0], 10)
+      const minorVersion = parseInt(versionParts[1], 10)
+
+      // Determine if version needs API prefix:
+      // - Versions >= 0.20.0 need API prefix
+      // - Also newer format versions (without leading 0) need API prefix
+      const needsApiPrefix = (majorVersion === 0 && minorVersion >= 20) || majorVersion > 0
+
+      if (this.currentPath === '/') {
+        return `/${version}${needsApiPrefix ? '/api/' : '/'}${this.currentHash}`
+      }
+
+      const normalizedPath = this.currentPath.replace('/api', '')
+      const prefix = needsApiPrefix ? '/api' : ''
+
+      return `/${version}${prefix}${normalizedPath}${this.currentHash}`
+    },
     switchVersion(event) {
       const newVersion = event.target.value
-      if (this.$page.typesenseVersion !== newVersion) {
-        let newPath = `/${newVersion}/`
-        const [ majorVersion, minorVersion, patchVersion] = newVersion.split('.')
-        if(majorVersion >= 0 && minorVersion >= 20) {
-          newPath += 'api/'
-        }
-        this.$router.push(newPath)
+      if (this.currentVersion !== newVersion) {
+        this.$router.push(this.getVersionedPath(newVersion))
       }
     },
   },

--- a/docs-site/content/.vuepress/components/VersionDropdown.vue
+++ b/docs-site/content/.vuepress/components/VersionDropdown.vue
@@ -64,10 +64,6 @@ export default {
       // - Also newer format versions (without leading 0) need API prefix
       const needsApiPrefix = (majorVersion === 0 && minorVersion >= 20) || majorVersion > 0
 
-      if (this.currentPath === '/') {
-        return `/${version}${needsApiPrefix ? '/api/' : '/'}${this.currentHash}`
-      }
-
       const normalizedPath = this.currentPath.replace('/api', '')
       const prefix = needsApiPrefix ? '/api' : ''
 


### PR DESCRIPTION
### TLDR
Maintains user's position in docs when switching between different Typesense versions. Closes #188

## Change Summary
#### Code Changes:
1. **In `VersionDropdown.vue`**:
   - Modified the [warning message](diffhunk://#diff-8ed94555eb24b9ab6404a3aab081d222da017446d39cf031cd367343b9730dd5L17-R19) to use the new `getVersionedPath` method for generating versioned paths
   - Added [computed properties](diffhunk://#diff-8ed94555eb24b9ab6404a3aab081d222da017446d39cf031cd367343b9730dd5L44-R79) `currentPath` and `currentHash` to extract the current route path and hash
   - Introduced the [getVersionedPath method](diffhunk://#diff-8ed94555eb24b9ab6404a3aab081d222da017446d39cf031cd367343b9730dd5L44-R79) to determine the correct path for the selected version, considering API prefix requirements
   - Refactored the [switchVersion method](diffhunk://#diff-8ed94555eb24b9ab6404a3aab081d222da017446d39cf031cd367343b9730dd5L44-R79) to use the `getVersionedPath` method for navigating to the selected version

### Context
- Previously, switching versions would always redirect users to the root page of the selected version, losing their position in the documentation (#188)
- The fix ensures a smoother user experience by maintaining context when navigating between different versions of the documentation

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
