### PR TITLE
Docs: Clarify limitations of synonyms with quoted searches and filtering

### DIFF
--- a/docs-site/content/28.0/api/synonyms.md
+++ b/docs-site/content/28.0/api/synonyms.md
@@ -21,6 +21,12 @@ When using Synonyms and [Overrides](./curation.md) together, Overrides are handl
 When a synonym has a `locale` specified, it will only be applied when searching fields with a matching locale. If no locale is specified for a synonym, it will be applied globally. This helps manage cases where the same word has different meanings across languages.
 :::
 
+:::tip Synonyms and Exact Match Queries / Filtering
+Quoted Searches: Synonyms do not work when the search query is wrapped in double quotes (e.g., "Sre" will not return results containing "Site Reliability Engineer" even if they are defined as multi-way synonyms).
+
+Filtering: Synonyms are not applied when using filter_by. For example, if you define a multi-way synonym for "abc <> xyz" and use filter_by: "title:=abc", it will only match documents where title="abc", not title="xyz".
+:::
+
 ## Create or update a synonym
 
 ### Multi-way synonym


### PR DESCRIPTION
## Change Summary
PR Description:
This PR updates the Synonyms documentation to clarify two limitations:

Quoted Searches: Synonyms are not applied when the search query is wrapped in double quotes (e.g., "Sre" will not return results containing "Site Reliability Engineer" even if they are defined as multi-way synonyms).

Filtering: Synonyms are not considered when using filter_by. For example, if a multi-way synonym is defined for "abc <> xyz" and the filter filter_by: "title:=abc" is used, it will only match documents where title="abc", not title="xyz".

These updates aim to help future users understand these behaviors and avoid confusion.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
