### PR TITLE
docs(stemming): improve explanation of stemming configuration options

### DIFF
--- a/docs-site/content/28.0/api/stemming.md
+++ b/docs-site/content/28.0/api/stemming.md
@@ -120,7 +120,7 @@ When configuring a field for stemming:
 
 1. Using `"stem": true` alone applies the default Porter stemmer algorithm
 1. Using `"stem_dictionary": "dictionary_name"` automatically enables stemming functionality (`"stem": true` is implied)
-1. When explicitly configuring both options on the same field, dictionary stemming takes precedence for words found in the dictionary, while the Porter algorithm handles words not in the dictionary
+1. When explicitly configuring both options on the same field, dictionary stemming takes precedence
 
 When you specify only `stem_dictionary` in your configuration, you'll notice `"stem": true` appears automatically in your schema because the system enables basic stemming by default when dictionary stemming is configured.
 :::

--- a/docs-site/content/28.0/api/stemming.md
+++ b/docs-site/content/28.0/api/stemming.md
@@ -115,8 +115,14 @@ curl "http://localhost:8108/collections" -X POST \
   </template>
 </Tabs>
 
-:::tip Combining Both Approaches
-You can use both basic stemming (`"stem": true`) and dictionary stemming (`"stem_dictionary": "dictionary_name"`) on the same field. When both are enabled, dictionary stemming takes precedence for words that exist in the dictionary.
+:::tip Understanding Stemming Options
+When configuring a field for stemming:
+
+1. Using `"stem": true` alone applies the default Porter stemmer algorithm
+1. Using `"stem_dictionary": "dictionary_name"` automatically enables stemming functionality (`"stem": true` is implied)
+1. When explicitly configuring both options on the same field, dictionary stemming takes precedence for words found in the dictionary, while the Porter algorithm handles words not in the dictionary
+
+When you specify only `stem_dictionary` in your configuration, you'll notice `"stem": true` appears automatically in your schema because the system enables basic stemming by default when dictionary stemming is configured.
 :::
 
 ### Managing Dictionaries


### PR DESCRIPTION
## Change Summary
- expand tip section to provide clearer explanation of stemming options
- add numbered list explaining different configuration scenarios
- clarify that `stem_dictionary` implies `stem: true` by default
- add explanation of how both stemming approaches work together

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
