### PR TITLE
fix error importing `typesenseLatestVersion` in Nuxt

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -18,9 +18,9 @@ As you write content in the content folder, the page should live reload.
 
 ### Adding images
 
-Place images in [content/.vuepress/public/images](content/.vuepress/public/images). Prefer using SVGs. 
+Place images in [content/.vuepress/public/images](content/.vuepress/public/images). Prefer using SVGs.
 
-Reference images in markdown files like this: 
+Reference images in markdown files like this:
 
 ```
 ![Typesense DynamoDB Integration Chart](~@images/typesense-dynamodb.svg)
@@ -33,7 +33,7 @@ where `typesense-dynamodb.svg` is located at `./content/.vuepress/public/images/
 These variables can be used in markdown files as `{{ variableName }}` or in Vue components.
 
 | Variable                            | Definition                                                                                                            |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | $page.typesenseVersion              | The current Typesense version that the user is looking at docs for. Will be `null` for non-versioned top level files. |
 | $site.themeConfig.typesenseVersions | List of all Typesense versions                                                                                        |
 
@@ -42,7 +42,7 @@ To partially fix the issue with page titles, we have a workaround in `plugins/ty
 
 ### Authoring a new version
 
-1. Add version number to `../typesenseVersions.js`
+1. Add version number to `../typesenseVersions.json`
 1. Clone the latest version directory and make edits to it.
 1. Update sitemap priority for old version:
    ```bash

--- a/typesense.org-v3/utils/index.ts
+++ b/typesense.org-v3/utils/index.ts
@@ -1,8 +1,6 @@
-// import * as version from "../../typesenseVersions";
+import { typesenseLatestVersion } from "../../typesenseVersions.json";
 export const STATIC = {
-  // TODO: this results in null values being displayed.
-  // typesenseLatestVersion: version.typesenseLatestVersion,
-  typesenseLatestVersion: '28.0',
+  typesenseLatestVersion,
   githubStars: "22K",
   dockerPulls: "18M",
   cloudSearchesPerMonth: "10B",

--- a/typesenseVersions.json
+++ b/typesenseVersions.json
@@ -1,6 +1,6 @@
-module.exports = {
-  typesenseLatestVersion: '28.0',
-  typesenseVersions: [
+{
+  "typesenseLatestVersion": "28.0",
+  "typesenseVersions": [
     "28.0",
     "27.1",
     "27.0",
@@ -26,6 +26,6 @@ module.exports = {
     "0.14.0",
     "0.13.0",
     "0.12.0",
-    "0.11.2",
-  ],
+    "0.11.2"
+  ]
 }


### PR DESCRIPTION

## Change Summary
<!--- Described your changes here -->
- Fixed by converting the commonJS file `typesenseVersions.js` to JSON so that both ES6 and CJS can import

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
