### PR TITLE
docs(convo-search): clarify behavior of multiple conversations in multisearch

### DIFF
--- a/docs-site/content/28.0/api/conversational-search-rag.md
+++ b/docs-site/content/28.0/api/conversational-search-rag.md
@@ -247,7 +247,8 @@ You can exclude conversation history from the search API response by setting `ex
 :::tip Multi-Search
 When using the `multi_search` endpoint with the Conversations feature, the `q` parameter has to be set as a query parameter and not as a body parameter inside a particular search.
 
-You can search multiple collections within the multi_search endpoint, and Typesense will use the top results from each collection when communicating with the LLM. 
+You can search multiple collections within the `multi_search` endpoint, and Typesense will use the top results from each collection when communicating with the LLM.
+If your `multi_search` request includes multiple searches with `conversation=true` (either through the common query parameters or within individual searches), only a single conversation object will be returned in the response. Typesense will use results from all searches in the `multi_search` to generate one answer based on data from multiple collections.
 :::
 
 :::tip Auto-Embedding Model


### PR DESCRIPTION


## Change Summary


- update `MultiSearch` tip section to explain that only one conversation object is returned
- clarify that this behavior is by design and intentional
- explain that results from all collections are used to generate a single comprehensive answer

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
