### PR TITLE
docs(faqs): add explanation about filtering behavior returning more results

### DIFF
--- a/docs-site/content/guide/faqs.md
+++ b/docs-site/content/guide/faqs.md
@@ -258,13 +258,15 @@ You might notice that adding a filter to your search query sometimes returns **m
 
 When you search with a keyword (e.g., "_shoes_") without filters, Typesense finds exact matches first. But when you add a filter, if the documents containing "_shoes_" don't match your filter criteria, Typesense will automatically look for typo variations or prefix matches (e.g., "_shoe_") to return relevant results that do satisfy your filter.
 
-You can control this behavior by increasing the `max_candidates` parameter:
+You can control this behavior by increasing the `max_candidates` parameter, and/or increasing the `drop_tokens_threshold` or the `typo_tokens_threshold` parameters as needed:
 
 ```json
 {
   "q": "shoes",
   "filter_by": "category:=Athletic",
-  "max_candidates": 100  // default is 4
+  "max_candidates": 100, 
+  "drop_tokens_threshold": 1000,
+  "typo_tokens_threshold": 1000
 }
 ```
 

--- a/docs-site/content/guide/faqs.md
+++ b/docs-site/content/guide/faqs.md
@@ -252,6 +252,24 @@ You could also do "starts with" matching using filter_by. For eg, say we want to
 }
 ```
 
+### Why do I sometimes get more results when adding filters?
+
+You might notice that adding a filter to your search query sometimes returns **more** results than the same search without filters. This is related to how Typesense handles typo tolerance and candidate matching when filters are applied.
+
+When you search with a keyword (e.g., "_shoes_") without filters, Typesense finds exact matches first. But when you add a filter, if the documents containing "_shoes_" don't match your filter criteria, Typesense will automatically look for typo variations or prefix matches (e.g., "_shoe_") to return relevant results that do satisfy your filter.
+
+You can control this behavior by increasing the `max_candidates` parameter:
+
+```json
+{
+  "q": "shoes",
+  "filter_by": "category:=Athletic",
+  "max_candidates": 100  // default is 4
+}
+```
+
+For a detailed explanation, see the <RouterLink :to="`/guide/tips-for-filtering.html#why-filters-can-sometimes-return-more-results`">Tips for Filtering</RouterLink> documentation.
+
 
 ## Semantic Search
 


### PR DESCRIPTION
## Change Summary
- Add new FAQ section explaining why filters can sometimes return more results
- Describe how Typesense handles typo tolerance with filters
- Include example JSON showing how to control behavior with `max_candidates`
- Add link to detailed explanation in filtering documentation


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
