### PR TITLE
Add Sequin to the sync real-time changes docs

### DIFF
--- a/docs-site/content/guide/syncing-data-into-typesense.md
+++ b/docs-site/content/guide/syncing-data-into-typesense.md
@@ -2,7 +2,7 @@
 
 Typesense offers a REST-ful API that you can use to keep data from your primary database in sync with Typesense.
 
-There are a couple of ways to do this, depending on your architecture, CPU capacity in your Typesense cluster and the amount of "realtime-ness" you need. 
+There are a couple of ways to do this, depending on your architecture, CPU capacity in your Typesense cluster and the amount of "realtime-ness" you need.
 
 [[toc]]
 
@@ -13,7 +13,7 @@ There are a couple of ways to do this, depending on your architecture, CPU capac
 1. Add an `updated_at` timestamp to every record in your primary database (if you don't already have one) and update it anytime you make changes to any records.
 2. For records that are deleted, either "soft delete" the record using an `is_deleted` boolean field that you set to `true` to delete the record, or save the deleted record's ID in a separate table with a `deleted_at` timestamp.
 3. On a periodic basis (say every 30s), query your database for all records that have an `updated_at` timestamp between the current time and the last time the sync process ran (you want to maintain this `last_synced_at` timestamp in a persistent store).
-4. Make a <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#index-multiple-documents`">Bulk Import API call</RouterLink> to Typesense with just the records in Step 3, with `action=upsert` 
+4. Make a <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#index-multiple-documents`">Bulk Import API call</RouterLink> to Typesense with just the records in Step 3, with `action=upsert`
 5. For records that were marked as deleted in Step 2, make a <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#delete-by-query`">Delete by Query</RouterLink> API call to Typesense with all the record IDs in a filter like this: `filter_by:=[id1,id2,id3]`.
 
 If you have data that spans multiple tables and your database supports the concept of views, you could create a database view that `JOIN`s all the tables you need and polls that view instead of individual tables.
@@ -22,10 +22,10 @@ If you have data that spans multiple tables and your database supports the conce
 
 If your primary database has the concept of change triggers or change data capture:
 
-1. You can write a listener to hook into these change streams and push the changes to a temporary queue 
-2. Every say 5s, have a scheduled job that reads all the changes from this queue and <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#index-multiple-documents`">bulk imports</RouterLink> them into Typesense. 
+1. You can write a listener to hook into these change streams and push the changes to a temporary queue
+2. Every say 5s, have a scheduled job that reads all the changes from this queue and <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#index-multiple-documents`">bulk imports</RouterLink> them into Typesense.
 
-For eg, here are a couple of ways to sync data from [MongoDB](./mongodb-full-text-search.md), [DynamoDB](./dynamodb-full-text-search.md) and [Firestore](./firebase-full-text-search.md). 
+For eg, here are a couple of ways to sync data from [MongoDB](./mongodb-full-text-search.md), [DynamoDB](./dynamodb-full-text-search.md) and [Firestore](./firebase-full-text-search.md).
 To sync data from MySQL using binlogs, there's [Maxwell](https://github.com/zendesk/maxwell) which will convert the binlogs into JSON and place it in a Kafka topic for you to consume.
 
 ### Using ORM Hooks
@@ -92,48 +92,58 @@ This buffer-based approach provides several benefits:
 - The buffer provides an audit trail of changes
 - You can tune the processing frequency based on your real-time requirements
 
-### Using Prisma Pulse
+### Using Sequin
 
-[Prisma Pulse](https://www.prisma.io/data-platform/pulse?utm_source=typesense&utm_medium=typesense-docs) extends the [Prisma ORM](https://www.prisma.io/orm?utm_source=typesense&utm_medium=typesense-docs) to simplify event-driven workflows for your database. It allows you to stream database changes to Typesense in real-time, keeping your search collections up-to-date with the latest data.
+[Sequin](https://sequinstream.com) streams data from your Postgres database to TypeSense in real-time. Any change to your database (whether from your application, an internal tool, or another process) will be immediately reflected in TypeSense.
 
-#### Setup at a glance
+This approach comes with several benefits:
 
-1. Prerequisites:
-   - Ensure you have Pulse set up and enabled alongside Typesense in your project. Read more on setting up Pulse in their [documentation](https://www.prisma.io/docs/pulse/getting-started).
-2. Stream database changes to Typesense:
-   Use Pulse's `.stream()` API to listen for database changes and sync them to your Typesense collections.
+- Sequin uses logical replication, which adds virtually no overhead to your database (unlike polling and triggers)
+- The direct integration with TypeSense leverages the bulk API to efficiently load every create and update. It also supports deletes out of the box.
+- You can tune Sequin's batching behavior to your real-time requirements
+- Sequin comes with transforms, backfills, filtering, and built-in retries to ensure your Postgres tables are perfectly replicated into TypeSense.
 
-Here's an example building on the `books` collection from the setup guide:
+#### Setup overview
 
-```typescript
-const stream = await prisma.book.stream({ name: "book-events" });
+:::tip
+Read Sequin's TypeSense [Quickstart](https://sequinstream.com/docs/quickstart/typesense) for a step-by-step guide.
+:::
 
-for await (const event of stream) {
-  switch (event.action) {
-    case "create":
-      const newBook = event.created; // Data of the newly created book record
-      await typesense.collections("books").documents().create(newBook);
-      break;
-    case "update":
-      const updatedBook = event.after; // Data of a book record after it has been updated
-      await typesense.collections("books").documents(updatedBook.id).update(updatedBook);
-      break;
-    case "delete":
-      const deletedBookId = event.deleted.id; // ID of the deleted book record
-      await typesense.collections("books").documents(deletedBookId).delete();
-      break;
-  }
-}
+1. Setup Sequin locally or create a cloud account.
+2. Connect your Postgres database to Sequin.
+3. Create a TypeSense sink for each table you want to replicate to a TypeSense collection.
+
+Here's an [example `Sequin.yaml`](https://sequinstream.com/docs/reference/sequin-yaml#typesense-sink) showing how to sink a `products` table to TypeSense:
+
+```yaml
+databases:
+  - name: "prod-db"
+    username: "postgres"
+    password: "postgres"
+    hostname: "my-database-instance.abcd1234wxyz.us-east-1.rds.amazonaws.com"
+    database: "prod"
+    port: 5432
+    slot_name: "sequin_slot"
+    publication_name: "sequin_pub"
+sinks:
+  - name: "typesense-sink"
+    database: "prod-db"
+    table: "public.products"
+    destination:
+        type: "typesense"
+        endpoint_url: "https://your-typesense-server:8108"
+        collection_name: "products"
+        api_key: "your-api-key"
+        batch_size: 1000
+        timeout_seconds: 5
 ```
-
-If you want to see how syncing data into Typesense with Prisma Pulse looks like in practice, check out this [ready-to-run example](https://github.com/prisma/prisma-examples/tree/latest/pulse/product-search-with-typesense).
 
 ## Full re-indexing
 
 In addition to the above strategies, you could also do a re-index of your entire dataset on say a nightly basis, just to make sure any gaps in the synced data due to schema validation errors, network issues, failed retries etc are addressed and filled.
 
-You could use the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/collection-alias.html`">Collection Alias</RouterLink> feature to do a reindex into a new collection and then switch the alias over to the new collection. 
-Or you can use the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#index-multiple-documents`">Bulk Import API</RouterLink> with `action=upsert`, along with the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#delete-by-query`">Delete by Query</RouterLink> endpoint on an existing collection and reimport your existing dataset. 
+You could use the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/collection-alias.html`">Collection Alias</RouterLink> feature to do a reindex into a new collection and then switch the alias over to the new collection.
+Or you can use the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#index-multiple-documents`">Bulk Import API</RouterLink> with `action=upsert`, along with the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/documents.html#delete-by-query`">Delete by Query</RouterLink> endpoint on an existing collection and reimport your existing dataset.
 
 ## Tips when importing data
 
@@ -157,17 +167,17 @@ Typesense write API calls are synchronous, so you do not want the client to term
 
 When the volume of writes sent to Typesense is high, Typesense will sometimes return an HTTP 503, Not Ready or Lagging.
 
-This is a backpressure mechanism built into Typesense, to ensure that heavy writes don't saturate CPU and end up affecting reads. 
+This is a backpressure mechanism built into Typesense, to ensure that heavy writes don't saturate CPU and end up affecting reads.
 
 If you see an HTTP 503, you want to do one or more of the following:
 
-1. Add more CPU cores so writes can be parallelized. We'd recommend a minimum of 4 CPU cores for high volume writes.  
-2. Make sure you've increased the client-side timeout (when instantiating the client library) to as high as say 60 minutes, so that the client never aborts writes that are in progress. 
+1. Add more CPU cores so writes can be parallelized. We'd recommend a minimum of 4 CPU cores for high volume writes.
+2. Make sure you've increased the client-side timeout (when instantiating the client library) to as high as say 60 minutes, so that the client never aborts writes that are in progress.
     Many a time a short client-side timeout ends up causing frequent retry writes of the same data, leading to a thundering herd issue.
 3. Increase the retry time interval in the client library to a larger number or set it to a random value between 10 and 60 seconds (especially in a serverless environment) to introduce some jitter in how quickly retries are attempted.
     This gives the Typesense process more time to catch up on previous writes.
 4. If you have a high volume of single-document write API calls, you want to switch to using the bulk import API endpoint, which is much more performant. See this dedicated section about handling [high volume writes](#high-volume-writes).
-5. If you have fields that you're only using for display purposes and not for searching / filtering / faceting / sorting / grouping, you want to leave them out of the schema to avoid having to index them. 
+5. If you have fields that you're only using for display purposes and not for searching / filtering / faceting / sorting / grouping, you want to leave them out of the schema to avoid having to index them.
     You can still send these fields in the document when sending it to Typesense - they'll just be stored on disk and returned when the document is a hit, instead of being indexed in memory.
     This will help avoid using unnecessary CPU cycles for indexing.
 6. Sometimes disk I/O might be a bottleneck, especially if each individual document is large. In these cases, you want to turn on High Performance Disk in Typesense Cloud or use nVME SSD disks to improve performance.
@@ -176,12 +186,12 @@ If you see an HTTP 503, you want to do one or more of the following:
 
 ### Handling Rejecting write: running out of resource type errors
 
-You might see "running out of resource type" errors either when running out of RAM (OUT_OF_MEMORY) or running of disk space (OUT_OF_DISK). 
+You might see "running out of resource type" errors either when running out of RAM (OUT_OF_MEMORY) or running of disk space (OUT_OF_DISK).
 
 The [amount of RAM](./system-requirements.md#choosing-ram) used by Typesense is directly proportional to the amount of data indexed in the Typesense node.
-So if you see `OUT_OF_MEMORY` errors, you want to add more RAM to fit your dataset in memory. 
+So if you see `OUT_OF_MEMORY` errors, you want to add more RAM to fit your dataset in memory.
 
-When you see `OUT_OF_DISK` you want to add more disk capacity and restart Typesense. 
+When you see `OUT_OF_DISK` you want to add more disk capacity and restart Typesense.
 On Typesense Cloud, we provision 5X disk space (or a minimum of 8GB) if X is the amount of RAM. So to add more disk space, you want to upgrade to the next RAM tier.
 
 ### Client-side batch size vs server-side batching

--- a/docs-site/content/guide/syncing-data-into-typesense.md
+++ b/docs-site/content/guide/syncing-data-into-typesense.md
@@ -94,26 +94,26 @@ This buffer-based approach provides several benefits:
 
 ### Using Sequin
 
-[Sequin](https://sequinstream.com) streams data from your Postgres database to TypeSense in real-time. Any change to your database (whether from your application, an internal tool, or another process) will be immediately reflected in TypeSense.
+[Sequin](https://sequinstream.com) streams data from your Postgres database to Typesense in real-time. Any change to your database (whether from your application, an internal tool, or another process) will be immediately reflected in Typesense.
 
 This approach comes with several benefits:
 
 - Sequin uses logical replication, which adds virtually no overhead to your database (unlike polling and triggers)
-- The direct integration with TypeSense leverages the bulk API to efficiently load every create and update. It also supports deletes out of the box.
+- The direct integration with Typesense leverages the bulk import API to efficiently load every create and update. It also supports deletes out of the box.
 - You can tune Sequin's batching behavior to your real-time requirements
-- Sequin comes with transforms, backfills, filtering, and built-in retries to ensure your Postgres tables are perfectly replicated into TypeSense.
+- Sequin comes with transforms, backfills, filtering, and built-in retries to ensure your Postgres tables are perfectly replicated into Typesense.
 
 #### Setup overview
 
 :::tip
-Read Sequin's TypeSense [Quickstart](https://sequinstream.com/docs/quickstart/typesense) for a step-by-step guide.
+Read Sequin's Typesense [Quickstart](https://sequinstream.com/docs/quickstart/typesense) for a step-by-step guide.
 :::
 
 1. Setup Sequin locally or create a cloud account.
 2. Connect your Postgres database to Sequin.
-3. Create a TypeSense sink for each table you want to replicate to a TypeSense collection.
+3. Create a Typesense sink for each table you want to replicate to a Typesense collection.
 
-Here's an [example `Sequin.yaml`](https://sequinstream.com/docs/reference/sequin-yaml#typesense-sink) showing how to sink a `products` table to TypeSense:
+Here's an [example `Sequin.yaml`](https://sequinstream.com/docs/reference/sequin-yaml#typesense-sink) showing how to sink a `products` table to Typesense:
 
 ```yaml
 databases:


### PR DESCRIPTION
## Change Summary
Adds [Sequin](https://sequinstream.com/) as an option for easily replicating Postgres into TypeSense. It also removes Prisma Pulse since that product is no longer available.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
