### PR TITLE
docs(imports): add note about max size of doc import

### DIFF
--- a/docs-site/content/28.0/api/documents.md
+++ b/docs-site/content/28.0/api/documents.md
@@ -1037,6 +1037,10 @@ parallel --block -5 -a documents.jsonl --tmpdir /tmp --pipepart --cat 'curl -H "
 
 <br/>
 
+:::warning 
+**Important Note**: Typesense limits individual import requests to a maximum of 10GB. For larger files, you should split them into smaller chunks and import them individually.
+:::
+
 ### Import a JSON file
 
 If you have a file in JSON format, you can convert it into JSONL format using [`jq`](https://github.com/stedolan/jq):


### PR DESCRIPTION
## Change Summary
Add a warning about the maximum size of JSONL files (10GB)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
