### PR TITLE
docs(joins): mention async refs inside objs

### DIFF
--- a/docs-site/content/28.0/api/joins.md
+++ b/docs-site/content/28.0/api/joins.md
@@ -492,6 +492,9 @@ the type of the reference field would have to be an array as well.
   ]
 }
 ```
+:::warning
+For references inside nested objects, the `async_reference` parameter is not supported. These references must be resolved at indexing time.
+:::
 
 ## Using aliases with Joins
 


### PR DESCRIPTION
## Change Summary
Mention that async referencing is not available in nested objects.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
