### PR TITLE
docs(filtering): add example for filtering on non-empty fields

### DIFF
--- a/docs-site/content/guide/tips-for-filtering.md
+++ b/docs-site/content/guide/tips-for-filtering.md
@@ -128,6 +128,12 @@ Then, to filter for records with empty descriptions:
 filter_by = description:=~~
 ```
 
+Similarly, to filter for records with non-empty descriptions, you can use the `!` operator:
+
+```shell
+filter_by = description:!~~
+```
+
 :::warning IMPORTANT Note about Placeholder Symbols
 
 Symbols are not indexed by default in Typesense. 


### PR DESCRIPTION
## Change Summary
Adds a simple example for filtering on fields with a non-empty value.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
