### PR TITLE
Fix typo in docsearch guide

### DIFF
--- a/docs-site/content/guide/docsearch.md
+++ b/docs-site/content/guide/docsearch.md
@@ -168,7 +168,7 @@ docker run -it \
 
 #### Set environment variables on the command line, rather than using a .env file
 
-I you don't want to use a `.env` file or cannot use one in your setup, you can also pass all variables on the command line:
+If you don't want to use a `.env` file or cannot use one in your setup, you can also pass all variables on the command line:
 
 ```bash
 docker run -it \


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

While going through the guide, under the section "Set environment variables on the command line, rather than using a .env file", I found a typo. This PR fixes it.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
