### PR TITLE
Fix incorrect instruction on hybrid search with external embedding

### DIFF
--- a/docs-site/content/29.0/api/vector-search.md
+++ b/docs-site/content/29.0/api/vector-search.md
@@ -3305,7 +3305,8 @@ During hybrid search, the `_text_match` clause in `sort_by` will refer to the co
 :::
 
 If you are populating the embedding field externally, without using auto-embedding, you can still do a hybrid
-search by passing the embedding of the query string manually via the `vector_query` parameter.
+search by passing the embedding of the query string manually via the `vector_query` parameter and omitting the 
+embedding field from `query_by`.
 
 ```shell
 curl 'http://localhost:8108/multi_search' \
@@ -3315,7 +3316,7 @@ curl 'http://localhost:8108/multi_search' \
           "searches": [
             {
               "q": "chair",
-              "query_by": "product_name,embedding",
+              "query_by": "product_name",
               "vector_query": "embedding:([0.2, 0.4, 0.1])",
               "sort_by": "_text_match:desc"
             }


### PR DESCRIPTION
Clarify that the embedding field should be omitted when populating the embedding externally.

If following the current docs, even when a `vector_query` is provided during hybrid search, typesense will ignore it and calculate auto-embedding anyway, if `embedding` is part of `query_by`.

If `embedding` is excluded from `query_by` and a `vector_query` is provided, the hybrid search works as expected.

The unexpected behavior (auto-embedding being run even though vector_query was provided) caused massive performance issues in my project, since I already did the embedding on a GPU beforehand and the CPU-based auto-embedding was very slow.

See this slack thread for more details: https://typesense-community.slack.com/archives/C01P749MET0/p1752134886083529

## Change Summary
Updated docs to reflect the actual behavior.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
