### PR TITLE
Update github-actions.md to improve the use of curl-ing as health checks

### DIFF
--- a/docs-site/content/guide/github-actions.md
+++ b/docs-site/content/guide/github-actions.md
@@ -72,7 +72,7 @@ jobs:
       - name: Start Typesense
         run: |
           docker run -d \
-          -p ${{ matrix.typesense-port }}
+          -p ${{ matrix.typesense-port }} \
           --name typesense \
           -v /tmp/typesense-data:/data \
           -v /tmp/typesense-analytics-data:/analytics-data \

--- a/docs-site/content/guide/github-actions.md
+++ b/docs-site/content/guide/github-actions.md
@@ -71,8 +71,8 @@ jobs:
     steps:
       - name: Start Typesense
         run: |
-          docker run -id \
-          -p 8108:8108 \
+          docker run -d \
+          -p ${{ matrix.typesense-port }}
           --name typesense \
           -v /tmp/typesense-data:/data \
           -v /tmp/typesense-analytics-data:/analytics-data \


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Previously we're using `sleep 1 && curl http://localhost:8108/health` which is cumbersome, especially if the runner is not done on starting a service (what if it took `x` seconds before operational?).

In this change, we're improving the use of curl by adding a simple counter with timeouts (30s) as health checks and prints how long before operational.

Also, bumping typesense-version coverage for this example workflow file

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
