### PR TITLE
Fix debug api endpoint example in install guide

### DIFF
--- a/docs-site/content/guide/install-typesense.md
+++ b/docs-site/content/guide/install-typesense.md
@@ -387,11 +387,12 @@ You can use the `/health` API end-point to verify that the server is ready to ac
 
 
 You can use the `/debug` API end-point to verify the version of Typesense running.
+See [Managing Access to Data](./data-access-control.md) for more information about using API keys.
 
 <Tabs :tabs="['Shell']">
   <template v-slot:Shell>
     <div class="manual-highlight">
-    <pre class="language-bash"><code>curl http://localhost:8108/debug
+    <pre class="language-bash"><code>curl -H 'X-TYPESENSE-API-KEY: xyz' http://localhost:8108/debug
 {
   "state": 1,
   "version": "{{ $site.themeConfig.typesenseLatestVersion }}"


### PR DESCRIPTION
The api key must be provided to the /debug endpoint. Only the /health endpoint doesn't require this,
as documented at https://typesense.org/docs/guide/data-access-control.html#managing-access-to-data .

Without the api key, you will see an error message:

```
$ curl http://localhost:8108/debug
{"message": "Forbidden - a valid `x-typesense-api-key` header must be sent."}
```

## Change Summary

- update /debug endpoint example so it works
- add link to data access control docs about api keys

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
