### PR TITLE
docs(synonyms): migrate synonyms api to synonym sets for v30 breaking change

### DIFF
--- a/docs-site/content/30.0/api/synonyms.md
+++ b/docs-site/content/30.0/api/synonyms.md
@@ -7,7 +7,7 @@ sitemap:
 # Synonym Sets
 
 :::warning Breaking Change in v30
-The old synonyms API has been deprecated and replaced with the new **synonym sets** API. All existing synonyms have been automatically migrated to the new synonym sets format. This is a breaking change that requires updating your code to use the new API endpoints.
+When you upgrade to v30, all existing collection-specific synonym definitions will be automatically migrated to the new synonym sets format. Your searches will continue working without any hiccups, but you have to use the new API and client methods for reading and writing to the synonym definitions.
 :::
 
 The synonym sets feature allows you to define search terms that should be considered equivalent. For example: when you define a synonym for `sneaker` as `shoe`, searching for `sneaker` will now return all records with the word `shoe` in them, in addition to records with the word `sneaker`.


### PR DESCRIPTION
## Change Summary

• replace old synonyms api with new synonym sets api structure • update all code examples
• add breaking change warning and migration guide
• restructure api endpoints from /collections/{collection}/synonyms/* to /synonym_sets/* • update data structure to use items array with id and synonyms • include automatic migration details for existing synonyms


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
