### PR TITLE
fix: fields inside object[] are arrays

### DIFF
--- a/docs-site/content/guide/tips-for-filtering.md
+++ b/docs-site/content/guide/tips-for-filtering.md
@@ -318,8 +318,8 @@ For example, consider a menu collection with the following schema:
   "fields": [
     {"name": "name", "type": "string"},
     {"name": "ingredients", "type": "object[]"},
-    {"name": "ingredients.name", "type": "string"},
-    {"name": "ingredients.concentration", "type": "int32"}
+    {"name": "ingredients.name", "type": "string[]"},
+    {"name": "ingredients.concentration", "type": "int32[]"}
   ],
   "enable_nested_fields": true
 }
@@ -364,6 +364,10 @@ This will return only Pasta and Pizza, because it matches objects within the ing
 
 :::warning Important Note
 The traditional filter syntax `ingredients.name:=cheese && ingredients.concentration:<50` would match all three records because it doesn't ensure the conditions apply to the same object in the array. Always use the `{...}` syntax when filtering on multiple fields within nested array objects.
+:::
+
+:::warning Important Note
+Fields inside object[] fields automatically become arrays, that is the reason that ingredients.name and ingredients.concentration are arrays, despite being single fields.
 :::
 
 You can use any valid filter operators inside the `{...}` block.

--- a/docs-site/content/guide/tips-for-filtering.md
+++ b/docs-site/content/guide/tips-for-filtering.md
@@ -367,7 +367,7 @@ The traditional filter syntax `ingredients.name:=cheese && ingredients.concentra
 :::
 
 :::warning Important Note
-Fields inside object[] fields automatically become arrays, that is the reason that ingredients.name and ingredients.concentration are arrays, despite being single fields.
+Fields inside `object[]` fields automatically become arrays. So we have to mark `ingredients.name` and `ingredients.concentration` as array fields, despite being single valued.
 :::
 
 You can use any valid filter operators inside the `{...}` block.


### PR DESCRIPTION
## Change Summary
Fix: Types from example JSON schema. Inside object[], all fields types are arrays.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
