### PR TITLE
Update Meilisearch's parts about Replication and Sharding support

### DIFF
--- a/docs-site/content/overview/comparison-with-alternatives.md
+++ b/docs-site/content/overview/comparison-with-alternatives.md
@@ -42,7 +42,6 @@ For example, additional sort orders require duplicate indices in both Algolia an
 Based on the project's documented limitations, it seems to be geared for small dataset sizes,
 and specifically for cases where high availability is not a requirement. Since it does not have multi-node clustering or node-node replication, it is not production-ready yet.
 
-That said, Meilisearch is a relatively new project, and while it's not suited for serious production use-cases today,
-the project has a good team & momentum behind it. We're eager to see how the project evolves.
+That said, Meilisearch is a relatively new project. The project has a good team & momentum behind it. We're eager to see how the project evolves.
 
 See a side-by-side feature comparison [here](https://typesense.org/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch/).

--- a/typesense.org-v3/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org-v3/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -94,11 +94,11 @@
                     Instant Search-as-you-type Experiences for use cases that
                     don't require a highly-available fault-tolerant setup.
                     <a
-                      href="https://www.meilisearch.com/docs/learn/engine/storage#:~:text=For%20the%20best%20performance%2C%20it%20is%20recommended%20to%20provide%20the%20same%20amount%20of%20RAM%20as%20the%20size%20the%20database%20takes%20on%20disk%2C%20so%20all%20the%20data%20structures%20can%20fit%20in%20memory"
+                      href="https://www.meilisearch.com/docs/learn/engine/storage#:~:text=RAM%E2%80%91to%E2%80%91disk%20ratio%20around%201%2F3%20does%20not%20materially%20impact%20performance"
                       target="_blank"
                       >Recommends</a
                     >
-                    providing enough RAM to hold entire dataset in RAM for ideal
+                    providing enough RAM to hold a third of the dataset in RAM for ideal
                     performance.
                   </td>
                 </tr>

--- a/typesense.org-v3/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org-v3/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -837,7 +837,7 @@
                   <td>
                     No limitation, constrained by available disk space and
                     <a
-                      href="https://www.meilisearch.com/docs/learn/engine/storage#:~:text=For%20the%20best%20performance%2C%20it%20is%20recommended%20to%20provide%20the%20same%20amount%20of%20RAM%20as%20the%20size%20the%20database%20takes%20on%20disk%2C%20so%20all%20the%20data%20structures%20can%20fit%20in%20memory"
+                      href="https://www.meilisearch.com/docs/learn/engine/storage#:~:text=RAM%E2%80%91to%E2%80%91disk%20ratio%20around%201%2F3%20does%20not%20materially%20impact%20performance"
                       target="_blank"
                     >
                       performance is constrained by available RAM</a

--- a/typesense.org-v3/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org-v3/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -91,8 +91,7 @@
                     datasets (eg: log data)
                   </td>
                   <td>
-                    Instant Search-as-you-type Experiences for use cases that
-                    don't require a highly-available fault-tolerant setup.
+                    Instant Search-as-you-type Experiences for use cases.
                     <a
                       href="https://www.meilisearch.com/docs/learn/engine/storage#:~:text=RAM%E2%80%91to%E2%80%91disk%20ratio%20around%201%2F3%20does%20not%20materially%20impact%20performance"
                       target="_blank"
@@ -160,9 +159,8 @@
                     replication
                   </td>
                   <td class="!text-[#DC3545]">
-                    <Cross class="text-[#490F0F]" /><br /><br />Only supports a
-                    single-node setup, which creates a single point of failure
-                    and so is not fault tolerant / production-ready.
+                    <Check class="text-[#263311]" /><br /><br />Virtual-naming-based
+                    multi-node clustering
                   </td>
                 </tr>
                 <tr>
@@ -194,7 +192,8 @@
                     <Cross class="text-[#490F0F]" /><br /><br />Not available as
                     part of hosted offering
                   </td>
-                  <td><Cross class="text-[#490F0F]" /></td>
+                  <td><Check class="text-[#263311]" /><br /><br />Available in
+                    Premium tier, called geo-replicated sharding</td>
                 </tr>
                 <tr>
                   <td class="font-weight-bold">Runtime Dependencies</td>

--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -164,11 +164,11 @@
                 <tr>
                   <td class="font-weight-bold">GPU Acceleration Support</td>
                   <td>
-                    ✅<br /><br />Can optionally use a GPU when available.
+                    ✅<br /><br />Can optionally use a GPU when available
                   </td>
                   <td>❌</td>
                   <td>❌</td>
-                  <td>❌</td>
+                  <td>✅<br /><br />Can optionally use a GPU to generate embeddings</td>
                 </tr>
                 <tr>
                   <td class="font-weight-bold">

--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -153,6 +153,15 @@
                   <td>✅<br /><br />Virtual-naming-based multi-node clustering</td>
                 </tr>
                 <tr>
+                  <td class="font-weight-bold">
+                    Sharding / <br />Horizontal Scaling
+                  </td>
+                  <td>❌<br /><br />Only supports vertical scaling</td>
+                  <td>✅</td>
+                  <td>✅</td>
+                  <td>✅<br /><br />Virtual-naming-based multi-node sharding</td>
+                </tr>
+                <tr>
                   <td class="font-weight-bold">GPU Acceleration Support</td>
                   <td>
                     ✅<br /><br />Can optionally use a GPU when available.

--- a/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
+++ b/typesense.org/pages/typesense-vs-algolia-vs-elasticsearch-vs-meilisearch.vue
@@ -150,11 +150,7 @@
                   <td>✅<br /><br />RAFT-based multi-node clustering</td>
                   <td>✅<br /><br />RAFT-based multi-node clustering</td>
                   <td>✅<br /><br />Active-passive replication</td>
-                  <td class="text-danger">
-                    ❌<br /><br />Only supports a single-node setup, which
-                    creates a single point of failure and so is not fault
-                    tolerant / production-ready.
-                  </td>
+                  <td>✅<br /><br />Virtual-naming-based multi-node clustering</td>
                 </tr>
                 <tr>
                   <td class="font-weight-bold">GPU Acceleration Support</td>


### PR DESCRIPTION
Yellow, the Typesense team 👋

## Change Summary
I have updated your comparison table to reflect our recent releases and, most importantly, [the release of geo-replicated sharding](https://github.com/meilisearch/meilisearch/releases/tag/v1.37.0). Users can now configure a cluster and define how to replicate and shard their documents. We use virtual-naming to let users scale horizontally, define a replication-only setup, or both simultaneously.

I also updated parts discussing the impact of available RAM on performance.

Thank you for your time, and have a great week-end 🌵

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
