### PR TITLE
docs(documents): add batch size parameter for document exports

### DIFF
--- a/docs-site/content/0.24.0/api/README.md
+++ b/docs-site/content/0.24.0/api/README.md
@@ -38,6 +38,7 @@ This release contains new features, performance improvements and important bug f
 - Ability to clone a collection schema (without documents), overrides and synonyms.
 - New highlight structure that mimics the original document structure. Nested fields are highlighted only in this new
   structure, which is returned in a key named `highlight` in the JSON response.
+- Export documents in chunks with the new `batch_size` parameter on the export endpoint.
 - Allow override rules to be processed past the first match via the `stop_processing` flag (default is `true`).
 - Support locale and symbols in synonyms via the `locale` and `symbols_to_index` options during synonym creation.
 - Allow cloning of collection schema & linked assets (like synonyms, overrides) from a reference collection.

--- a/docs-site/content/0.24.0/api/documents.md
+++ b/docs-site/content/0.24.0/api/documents.md
@@ -1440,6 +1440,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting.                                            |
 
 **Definition**
 

--- a/docs-site/content/0.24.1/api/documents.md
+++ b/docs-site/content/0.24.1/api/documents.md
@@ -1440,6 +1440,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/0.25.0/api/documents.md
+++ b/docs-site/content/0.25.0/api/documents.md
@@ -1557,6 +1557,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/0.25.1/api/documents.md
+++ b/docs-site/content/0.25.1/api/documents.md
@@ -1557,6 +1557,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/0.25.2/api/documents.md
+++ b/docs-site/content/0.25.2/api/documents.md
@@ -1557,6 +1557,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/26.0/api/documents.md
+++ b/docs-site/content/26.0/api/documents.md
@@ -1560,6 +1560,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/27.0/api/documents.md
+++ b/docs-site/content/27.0/api/documents.md
@@ -1567,6 +1567,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/27.1/api/documents.md
+++ b/docs-site/content/27.1/api/documents.md
@@ -1732,6 +1732,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/28.0/api/documents.md
+++ b/docs-site/content/28.0/api/documents.md
@@ -1830,6 +1830,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/29.0/api/documents.md
+++ b/docs-site/content/29.0/api/documents.md
@@ -1830,6 +1830,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/30.0/api/documents.md
+++ b/docs-site/content/30.0/api/documents.md
@@ -1830,6 +1830,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 

--- a/docs-site/content/30.1/api/documents.md
+++ b/docs-site/content/30.1/api/documents.md
@@ -1830,6 +1830,7 @@ While exporting, you can use the following parameters to control the result of t
 | filter_by      | Restrict the exports to documents that satisfies the [`filter by` query](search.md#filter-results). |
 | include_fields | List of fields that should be present in the exported documents.                                    |
 | exclude_fields | List of fields that should not be present in the exported documents.                                |
+| batch_size     | Number of documents to stream per chunk while exporting. Default: `100`.                          |
 
 **Definition**
 


### PR DESCRIPTION
## Change Summary
It's been supported since v0.24: https://github.com/typesense/typesense/commit/a5628f9940786d443d5a3e6a0af1502863d3a1db

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
