### PR TITLE
fix(docs): fix tags field in curation examples

### DIFF
--- a/docs-site/content/30.0/api/curation.md
+++ b/docs-site/content/30.0/api/curation.md
@@ -386,9 +386,9 @@ You can add tags to override rules and then trigger curation by referring to the
       "id": "tagging-example",
       "rule": {
         "query": "iphone pro",
-        "match": "exact"
+        "match": "exact",
+        "tags": ["apple", "iphone"]
       },
-      "tags": ["apple", "iphone"],
       "includes": [{"id": "1348","position": 1}],
       "excludes": [
         {"id": "287"}

--- a/docs-site/content/30.1/api/curation.md
+++ b/docs-site/content/30.1/api/curation.md
@@ -386,9 +386,9 @@ You can add tags to override rules and then trigger curation by referring to the
       "id": "tagging-example",
       "rule": {
         "query": "iphone pro",
-        "match": "exact"
+        "match": "exact",
+        "tags": ["apple", "iphone"]
       },
-      "tags": ["apple", "iphone"],
       "includes": [{"id": "1348","position": 1}],
       "excludes": [
         {"id": "287"}


### PR DESCRIPTION
## Change Summary
The API payload example was wrong, as outlined in https://github.com/typesense/typesense/issues/2851

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
