### PR TITLE
docs(filtering): fix precedence mention of boolean operators

### DIFF
--- a/docs-site/content/guide/tips-for-filtering.md
+++ b/docs-site/content/guide/tips-for-filtering.md
@@ -215,7 +215,7 @@ For example, to filter for products that are either made in the USA or Canada, a
 
 ### Operator Precedence
 
-In boolean operations, the AND operator (`&&`) has higher precedence than the OR operator (`||`). This means that AND operations are performed before OR operations, unless parentheses are used to specify a different order.
+In boolean operations, the AND operator (`&&`) and the OR operator (`||`) have the same precedence and are evaluated left to right, unless parentheses are used to specify a different order.
 
 For example:
 
@@ -226,13 +226,13 @@ country:=USA || country:=Canada && city:=New York
 Would be interpreted as:
 
 ```shell
-country:=USA || (country:=Canada && city:=New York)
+(country:=USA || country:=Canada) && city:=New York
 ```
 
-To change the order of operations, use parentheses:
+To force a different order of operations, use parentheses explicitly:
 
 ```shell
-(country:=USA || country:=Canada) && city:=New York
+country:=USA || (country:=Canada && city:=New York)
 ```
 
 ## Filtering Array Types


### PR DESCRIPTION
## Change Summary
close https://github.com/typesense/typesense/issues/2882

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
