### PR TITLE
feat(docs): improve markdown copy actions

### DIFF
--- a/docs-site/content/.vuepress/components/CopySectionButton.vue
+++ b/docs-site/content/.vuepress/components/CopySectionButton.vue
@@ -122,29 +122,50 @@ export default {
 
       let sectionStart = -1
       let sectionEnd = lines.length
+      let activeFence = null
 
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i]
+      lines.forEach((line, lineIndex) => {
+        const fence = this.getFenceMarker(line)
+        if (fence) {
+          activeFence = activeFence === fence ? null : activeFence || fence
+        }
 
         if (sectionStart === -1) {
           if (line === targetLine) {
-            sectionStart = i
+            sectionStart = lineIndex
           }
-        } else {
-          // start, look for end (next heading of equal or higher level)
-          const level = this.getHeadingLevel(line)
-          if (level > 0 && level <= this.headingLevel) {
-            sectionEnd = i
-            break
-          }
+          return
         }
-      }
+
+        if (activeFence) {
+          return
+        }
+
+        const level = this.getHeadingLevel(line)
+        if (level > 0 && level <= this.headingLevel && sectionEnd === lines.length) {
+          sectionEnd = lineIndex
+        }
+      })
 
       if (sectionStart === -1) {
         return null
       }
 
       return lines.slice(sectionStart, sectionEnd).join('\n')
+    },
+
+    getFenceMarker(line) {
+      const trimmedLine = line.trim()
+
+      if (trimmedLine.startsWith('```')) {
+        return '```'
+      }
+
+      if (trimmedLine.startsWith('~~~')) {
+        return '~~~'
+      }
+
+      return null
     },
 
     getHeadingLevel(line) {

--- a/docs-site/content/.vuepress/components/CopySectionButton.vue
+++ b/docs-site/content/.vuepress/components/CopySectionButton.vue
@@ -38,6 +38,8 @@
 </template>
 
 <script>
+const { filterMarkdownByCopyLanguages, getPreferredCopyLanguages } = require('../util/markdownCopyFilter')
+
 export default {
   name: 'CopySectionButton',
   props: {
@@ -90,7 +92,13 @@ export default {
           throw new Error('Markdown content not available')
         }
 
-        const sectionMarkdown = this.extractSection(markdown)
+        const copyLanguages = getPreferredCopyLanguages()
+        const filteredMarkdown = filterMarkdownByCopyLanguages(
+          markdown,
+          this.$page.markdownCopyTabGroups,
+          copyLanguages,
+        )
+        const sectionMarkdown = this.extractSection(filteredMarkdown)
         if (!sectionMarkdown) {
           throw new Error('Could not find section')
         }

--- a/docs-site/content/.vuepress/components/CopySectionButton.vue
+++ b/docs-site/content/.vuepress/components/CopySectionButton.vue
@@ -1,9 +1,9 @@
 <template>
   <button
     class="copy-section-button"
-    @click.prevent.stop="copySection"
     :title="buttonTitle"
     :class="{ copied: isCopied }"
+    @click.prevent.stop="copySection"
   >
     <span class="icon-container">
       <svg

--- a/docs-site/content/.vuepress/components/MarkdownActions.vue
+++ b/docs-site/content/.vuepress/components/MarkdownActions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="markdown-actions">
-    <button class="copy-markdown-button" @click="copyMarkdown" :class="{ copied: isCopied }" :title="buttonTitle">
+    <button class="copy-markdown-button" :class="{ copied: isCopied }" :title="buttonTitle" @click="copyMarkdown">
       <div class="icon-container">
         <svg
           class="copy-icon"

--- a/docs-site/content/.vuepress/components/MarkdownActions.vue
+++ b/docs-site/content/.vuepress/components/MarkdownActions.vue
@@ -96,7 +96,11 @@
             :key="language"
             type="button"
             class="copy-language-option"
-            :class="{ unavailable: !isLanguagePresent(language), active: isLanguageSelected(language) }"
+            :class="{
+              unavailable: !isLanguagePresent(language),
+              active: isLanguageSelected(language),
+              'selected-unavailable': isLanguageSelected(language) && !isLanguagePresent(language),
+            }"
             :disabled="!isLanguagePresent(language)"
             :aria-checked="isLanguageSelected(language) ? 'true' : 'false'"
             :aria-disabled="!isLanguagePresent(language) ? 'true' : 'false'"
@@ -260,7 +264,7 @@ export default {
       this.showOptions = !this.showOptions
     },
     isLanguageSelected(language) {
-      return this.isLanguagePresent(language) && this.selectedLanguages.includes(language)
+      return this.selectedLanguages.includes(language)
     },
     isLanguagePresent(language) {
       return this.presentLanguages.includes(language)
@@ -287,7 +291,9 @@ export default {
       if (this.allAvailableLanguagesSelected) {
         this.selectedLanguages = this.selectedLanguages.filter(language => !this.isLanguagePresent(language))
       } else {
-        this.selectedLanguages = this.presentLanguages.slice()
+        this.selectedLanguages = this.languageOptions.filter(
+          language => !this.isLanguagePresent(language) ? this.selectedLanguages.includes(language) : true,
+        )
       }
 
       setPreferredCopyLanguages(this.selectedLanguages)
@@ -587,6 +593,15 @@ export default {
     > span:first-of-type + span
       color lighten($textColor, 45%)
       font-weight 500
+
+  &.selected-unavailable
+    border-color transparent
+
+    .copy-language-checkbox[data-state='checked']
+      background lighten($accentColor, 42%)
+      border-color lighten($accentColor, 42%)
+      color rgba(255, 255, 255, 0.88)
+      box-shadow none
 
   &.unavailable:hover
     background transparent

--- a/docs-site/content/.vuepress/components/MarkdownActions.vue
+++ b/docs-site/content/.vuepress/components/MarkdownActions.vue
@@ -34,8 +34,99 @@
           <polyline points="20 6 9 17 4 12"></polyline>
         </svg>
       </div>
-      <span>{{ buttonText }}</span>
+      <span class="copy-markdown-label">{{ buttonText }}</span>
     </button>
+    <div v-if="hasLanguageFilters" class="copy-options">
+      <button
+        class="copy-options-button"
+        type="button"
+        aria-haspopup="dialog"
+        :aria-expanded="showOptions ? 'true' : 'false'"
+        title="Choose copied languages"
+        @click.prevent.stop="toggleOptions"
+      >
+        <svg
+          class="copy-options-braces"
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10 3C7.6 3 6.5 4.3 6.5 6.8v1.8c0 1.2-.6 2.1-2 2.7 1.4.5 2 1.5 2 2.7v1.8c0 2.5 1.1 3.8 3.5 3.8" />
+          <path d="M14 3c2.4 0 3.5 1.3 3.5 3.8v1.8c0 1.2.6 2.1 2 2.7-1.4.5-2 1.5-2 2.7v1.8c0 2.5-1.1 3.8-3.5 3.8" />
+        </svg>
+        <svg
+          class="copy-options-chevron"
+          xmlns="http://www.w3.org/2000/svg"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </button>
+      <transition name="copy-options-popover">
+        <div v-if="showOptions" ref="optionsPopover" class="copy-options-popover" role="dialog" @click.stop>
+          <div class="copy-options-heading">
+            <div class="copy-options-heading-text">
+              <span>Copy languages</span>
+              <div class="copy-options-description">Choose which tabbed code examples are included when copying markdown.</div>
+            </div>
+          </div>
+          <div class="copy-options-meta">
+            <div class="copy-options-title">{{ availableLanguageCount }} available on this page</div>
+            <button type="button" class="copy-options-clear" @click.prevent.stop="toggleAllAvailableLanguages">
+              {{ allAvailableLanguagesSelected ? 'Deselect all' : 'Select all' }}
+            </button>
+          </div>
+          <button
+            v-for="language in languageOptions"
+            :key="language"
+            type="button"
+            class="copy-language-option"
+            :class="{ unavailable: !isLanguagePresent(language), active: isLanguageSelected(language) }"
+            :disabled="!isLanguagePresent(language)"
+            :aria-checked="isLanguageSelected(language) ? 'true' : 'false'"
+            :aria-disabled="!isLanguagePresent(language) ? 'true' : 'false'"
+            role="checkbox"
+            @click.prevent.stop="handleLanguageClick(language)"
+          >
+            <span class="copy-language-option-main">
+              <span class="copy-language-checkbox" :data-state="isLanguageSelected(language) ? 'checked' : 'unchecked'">
+                <svg
+                  v-if="isLanguageSelected(language)"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="3"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+              </span>
+              <span>{{ language }}</span>
+            </span>
+            <span v-if="!isLanguagePresent(language)" class="copy-language-status">Unavailable</span>
+          </button>
+        </div>
+      </transition>
+    </div>
     <a v-if="markdownUrl" :href="markdownUrl" class="view-markdown-button" title="View raw markdown" target="_blank">
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -57,12 +148,21 @@
 </template>
 
 <script>
+const {
+  COPY_LANGUAGE_OPTIONS,
+  filterMarkdownByCopyLanguages,
+  getPreferredCopyLanguages,
+  setPreferredCopyLanguages,
+} = require('../util/markdownCopyFilter')
+
 export default {
   name: 'MarkdownActions',
   data() {
     return {
       isCopied: false,
       copyTimeout: null,
+      selectedLanguages: [],
+      showOptions: false,
     }
   },
   computed: {
@@ -77,6 +177,26 @@ export default {
       if (!url) return null
       return this.$withBase(url)
     },
+    presentLanguages() {
+      const languages = this.$page && this.$page.markdownCopyLanguages
+      return Array.isArray(languages) ? languages : []
+    },
+    languageOptions() {
+      return COPY_LANGUAGE_OPTIONS
+    },
+    hasLanguageFilters() {
+      return this.presentLanguages.length > 0
+    },
+    availableLanguageCount() {
+      return this.presentLanguages.length
+    },
+    allAvailableLanguagesSelected() {
+      if (this.presentLanguages.length === 0) {
+        return false
+      }
+
+      return this.presentLanguages.every(language => this.selectedLanguages.includes(language))
+    },
   },
   watch: {
     $route() {
@@ -85,14 +205,26 @@ export default {
         this.copyTimeout = null
       }
       this.isCopied = false
+      this.showOptions = false
+      this.selectedLanguages = this.normalizeStoredLanguages(getPreferredCopyLanguages())
     },
+  },
+  mounted() {
+    this.selectedLanguages = this.normalizeStoredLanguages(getPreferredCopyLanguages())
+    document.addEventListener('click', this.closeOptionsOnOutsideClick)
+    document.addEventListener('keydown', this.closeOptionsOnEscape)
   },
   beforeDestroy() {
     if (this.copyTimeout) {
       clearTimeout(this.copyTimeout)
     }
+    document.removeEventListener('click', this.closeOptionsOnOutsideClick)
+    document.removeEventListener('keydown', this.closeOptionsOnEscape)
   },
   methods: {
+    normalizeStoredLanguages(languages) {
+      return this.languageOptions.filter(language => languages.includes(language))
+    },
     async copyMarkdown() {
       if (this.copyTimeout) {
         clearTimeout(this.copyTimeout)
@@ -106,7 +238,13 @@ export default {
           throw new Error('Markdown content not available')
         }
 
-        await navigator.clipboard.writeText(page.markdown)
+        const markdown = filterMarkdownByCopyLanguages(
+          page.markdown,
+          page.markdownCopyTabGroups,
+          this.selectedLanguages,
+        )
+
+        await navigator.clipboard.writeText(markdown)
 
         this.copyTimeout = setTimeout(() => {
           this.isCopied = false
@@ -116,6 +254,59 @@ export default {
         console.error('Failed to copy markdown:', error)
         this.isCopied = false
         alert('Failed to copy markdown. Please try again.')
+      }
+    },
+    toggleOptions() {
+      this.showOptions = !this.showOptions
+    },
+    isLanguageSelected(language) {
+      return this.isLanguagePresent(language) && this.selectedLanguages.includes(language)
+    },
+    isLanguagePresent(language) {
+      return this.presentLanguages.includes(language)
+    },
+    handleLanguageClick(language) {
+      if (!this.isLanguagePresent(language)) {
+        return
+      }
+
+      this.toggleLanguage(language)
+    },
+    toggleLanguage(language) {
+      if (this.isLanguageSelected(language)) {
+        this.selectedLanguages = this.selectedLanguages.filter(selectedLanguage => selectedLanguage !== language)
+      } else {
+        if (!this.selectedLanguages.includes(language)) {
+          this.selectedLanguages = this.selectedLanguages.concat(language)
+        }
+      }
+
+      setPreferredCopyLanguages(this.selectedLanguages)
+    },
+    toggleAllAvailableLanguages() {
+      if (this.allAvailableLanguagesSelected) {
+        this.selectedLanguages = this.selectedLanguages.filter(language => !this.isLanguagePresent(language))
+      } else {
+        this.selectedLanguages = this.presentLanguages.slice()
+      }
+
+      setPreferredCopyLanguages(this.selectedLanguages)
+    },
+    closeOptionsOnOutsideClick(event) {
+      if (!this.showOptions) {
+        return
+      }
+
+      const popover = this.$refs.optionsPopover
+      if (this.$el.contains(event.target) || (popover && popover.contains(event.target))) {
+        return
+      }
+
+      this.showOptions = false
+    },
+    closeOptionsOnEscape(event) {
+      if (event.key === 'Escape') {
+        this.showOptions = false
       }
     },
   },
@@ -143,14 +334,16 @@ export default {
 .markdown-actions
   display flex
   align-items stretch
+  position relative
   border 1px solid #e1e1e1
   border-radius 3px
-  overflow hidden
+  overflow visible
   background-color #f8f8f8
 
 .copy-markdown-button
   display inline-flex
   align-items center
+  justify-content center
   gap 0.35rem
   padding 0.2rem 0.45rem
   background-color transparent
@@ -159,6 +352,7 @@ export default {
   color #2c3e50
   font-size 0.75rem
   font-weight 500
+  line-height 1
   cursor pointer
   transition all 0.2s ease
   white-space nowrap
@@ -205,6 +399,15 @@ export default {
       transform scale(1) rotate(0deg)
       opacity 1
 
+  > span
+    display inline-flex
+    align-items center
+    line-height 1
+
+  .copy-markdown-label
+    display inline-flex
+    align-items center
+
 .view-markdown-button
   display inline-flex
   align-items center
@@ -236,10 +439,249 @@ export default {
   svg
     flex-shrink 0
 
+.copy-options
+  position relative
+  display flex
+
+.copy-options-button
+  display inline-flex
+  align-items center
+  justify-content center
+  gap 0.2rem
+  padding 0 0.45rem
+  background-color transparent
+  border none
+  border-right 1px solid #e1e1e1
+  color #2c3e50
+  font-size 0.75rem
+  font-weight 500
+  line-height 1
+  cursor pointer
+  transition all 0.2s ease
+
+  &:hover
+    background-color rgba(0, 0, 0, 0.04)
+
+  &[aria-expanded='true']
+    background-color rgba(217, 3, 104, 0.04)
+
+  .copy-options-braces
+    display block
+    flex-shrink 0
+    width 1rem
+    height 1rem
+    transition color 0.18s ease
+
+  .copy-options-chevron
+    flex-shrink 0
+    width 0.55rem
+    height 0.55rem
+    opacity 0.6
+    transition transform 0.2s ease
+
+  &[aria-expanded='true'] .copy-options-chevron
+    transform rotate(180deg)
+
+.copy-options-popover
+  position absolute
+  top calc(100% + 0.35rem)
+  right 0
+  z-index 20
+  width 15rem
+  margin-top 0.25rem
+  padding 0.5rem
+  background $white
+  border 1px solid $borderColor
+  border-radius 8px
+  box-shadow 0 12px 28px rgba(49, 49, 50, 0.12)
+  font-family inherit
+  transform-origin top right
+
+.copy-options-popover-enter-active,
+.copy-options-popover-leave-active
+  transition opacity 0.18s ease, transform 0.18s ease
+
+.copy-options-popover-enter,
+.copy-options-popover-leave-to
+  opacity 0
+  transform translateY(-4px) scale(0.98)
+
+.copy-options-heading
+  display flex
+  align-items flex-start
+  padding 0.1rem 0.5625rem 0.55rem
+  margin-bottom 0.4rem
+  border-bottom 1px solid $borderColor
+  color $textColor
+  font-size 0.95rem
+  font-weight 600
+  white-space nowrap
+
+.copy-options-heading-text
+  display flex
+  flex-direction column
+  align-items flex-start
+  min-width 0
+
+.copy-options-meta
+  display flex
+  align-items center
+  justify-content space-between
+  gap 0.75rem
+  padding 0 0.5625rem 0.45rem
+
+.copy-options-title
+  color lighten($textColor, 35%)
+  font-size 0.68rem
+  font-weight 500
+  white-space nowrap
+
+.copy-options-description
+  padding-top 0.2rem
+  color lighten($textColor, 18%)
+  font-size 0.72rem
+  font-weight 400
+  line-height 1.4
+  white-space normal
+
+.copy-language-option
+  display flex
+  align-items center
+  justify-content space-between
+  width 100%
+  gap 0.65rem
+  padding 0.45rem 0.5rem
+  margin 0
+  color $textColor
+  line-height 1.3
+  text-align left
+  background transparent
+  border 1px solid transparent
+  border-radius 4px
+  cursor pointer
+  transition background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease
+
+  &:hover
+    background $lightGrayColor
+
+  &:active
+    background darken($lightGrayColor, 4%)
+
+  &:disabled
+    cursor not-allowed
+
+  &.active
+    border-color transparent
+
+  &.unavailable
+    color lighten($textColor, 38%)
+
+    .copy-language-option-main
+      color lighten($textColor, 38%)
+
+    .copy-language-checkbox
+      background lighten($borderColor, 45%)
+      border-color lighten($borderColor, 12%)
+      color transparent
+
+    > span:first-of-type + span
+      color lighten($textColor, 45%)
+      font-weight 500
+
+  &.unavailable:hover
+    background transparent
+    border-color transparent
+
+.copy-language-option-main
+  display inline-flex
+  align-items center
+  gap 0.65rem
+  min-width 0
+
+.copy-language-checkbox
+  display inline-flex
+  align-items center
+  justify-content center
+  flex-shrink 0
+  width 1rem
+  height 1rem
+  padding 0
+  background $white
+  border 1.5px solid darken($borderColor, 14%)
+  border-radius 3px
+  color #fff
+  transition background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease
+
+  &[data-state='checked']
+    background $accentColor
+    border-color $accentColor
+    box-shadow 0 0 0 1px rgba(213, 39, 131, 0.08)
+
+  svg
+    width 0.7rem
+    height 0.7rem
+
+.copy-language-status
+  margin-left auto
+  color lighten($textColor, 45%)
+  font-size 0.65rem
+  font-weight 600
+  letter-spacing 0
+
+.copy-options-clear
+  display inline-flex
+  align-items center
+  justify-content center
+  flex-shrink 0
+  padding 0
+  background transparent
+  border none
+  color $accentColor
+  font-size 0.68rem
+  font-weight 600
+  cursor pointer
+  transition color 0.15s ease
+
+  &:hover
+    text-decoration underline
+
 @media (max-width: 719px)
+  .markdown-actions
+    max-width 100%
+    flex-wrap wrap
+
   .copy-markdown-button
     font-size 0.8125rem
     padding 0.5rem 0.75rem
+    min-width 0
+
+  .copy-options-button
+    font-size 0.8125rem
+    padding 0 0.45rem
+
+  .copy-options
+    position static
+
+  .copy-options-popover
+    left 0
+    right auto
+    width 15rem
+    max-width 92vw
+
+  .copy-options-meta
+    gap 0.5rem
+
+  .copy-options-title
+    white-space normal
+
+  .copy-options-clear
+    flex-shrink 0
+
+  .copy-language-option
+    gap 0.5rem
+
+  .copy-language-status
+    font-size 0.62rem
 
   .h1-with-actions
     flex-direction column

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { stripVueMarkdownWrappers } = require('../util/markdownCopy')
+const { analyzeMarkdownForCopy, stripVueMarkdownWrappers } = require('../util/markdownCopy')
 
 function withBase(base, url) {
   if (!url || /^https?:\/\//.test(url) || !base || base === '/') return url
@@ -68,7 +68,11 @@ module.exports = (options, context) => ({
 
       markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
 
-      $page.markdown = stripVueMarkdownWrappers(markdown)
+      const markdownCopyData = analyzeMarkdownForCopy(markdown)
+
+      $page.markdown = markdownCopyData.markdown
+      $page.markdownCopyTabGroups = markdownCopyData.copyTabGroups
+      $page.markdownCopyLanguages = markdownCopyData.copyLanguages
 
       if ($page.path.endsWith('/')) {
         $page.markdownUrl = `${$page.path}README.md`

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const { stripVueMarkdownWrappers } = require('../util/markdownCopy')
 
 function withBase(base, url) {
   if (!url || /^https?:\/\//.test(url) || !base || base === '/') return url
@@ -42,6 +43,7 @@ module.exports = (options, context) => ({
           console.log('Reading file:', sourceFile)
           let markdown = fs.readFileSync(sourceFile, 'utf-8')
           markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+          markdown = stripVueMarkdownWrappers(markdown)
 
           res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
           res.send(markdown)
@@ -66,7 +68,7 @@ module.exports = (options, context) => ({
 
       markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
 
-      $page.markdown = markdown
+      $page.markdown = stripVueMarkdownWrappers(markdown)
 
       if ($page.path.endsWith('/')) {
         $page.markdownUrl = `${$page.path}README.md`
@@ -101,6 +103,7 @@ module.exports = (options, context) => ({
         let markdown = fs.readFileSync(sourceFile, 'utf-8')
 
         markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+        markdown = stripVueMarkdownWrappers(markdown)
 
         let outputPath
         if (page.path.endsWith('/')) {

--- a/docs-site/content/.vuepress/util/copyLanguages.js
+++ b/docs-site/content/.vuepress/util/copyLanguages.js
@@ -1,0 +1,5 @@
+const COPY_LANGUAGE_OPTIONS = ['JavaScript', 'PHP', 'Python', 'Ruby', 'Dart', 'Java', 'Go', 'Swift', 'Shell']
+
+module.exports = {
+  COPY_LANGUAGE_OPTIONS,
+}

--- a/docs-site/content/.vuepress/util/markdownCopy.js
+++ b/docs-site/content/.vuepress/util/markdownCopy.js
@@ -1,0 +1,50 @@
+const MarkdownIt = require('markdown-it')
+
+const markdownParser = new MarkdownIt({ html: true })
+
+function isVueMarkdownWrapperLine(line) {
+  const trimmedLine = line.trim()
+
+  if (trimmedLine === '</Tabs>' || trimmedLine === '</template>') {
+    return true
+  }
+
+  if (trimmedLine.startsWith('<Tabs')) {
+    const nextCharacter = trimmedLine.charAt('<Tabs'.length)
+    return nextCharacter === '' || nextCharacter === ' ' || nextCharacter === '>' || nextCharacter === '/'
+  }
+
+  if (trimmedLine.startsWith('<template')) {
+    const nextCharacter = trimmedLine.charAt('<template'.length)
+    return (
+      (nextCharacter === '' || nextCharacter === ' ' || nextCharacter === '>' || nextCharacter === '/') &&
+      trimmedLine.includes('v-slot')
+    )
+  }
+
+  return false
+}
+
+function stripVueMarkdownWrappers(markdown) {
+  const lines = markdown.split('\n')
+  const tokens = markdownParser.parse(markdown, {})
+  const linesToRemove = new Set()
+
+  tokens.forEach(token => {
+    if (token.type !== 'html_block' || !token.map) {
+      return
+    }
+
+    for (let lineNumber = token.map[0]; lineNumber < token.map[1]; lineNumber += 1) {
+      if (isVueMarkdownWrapperLine(lines[lineNumber])) {
+        linesToRemove.add(lineNumber)
+      }
+    }
+  })
+
+  return lines.filter((_, lineNumber) => !linesToRemove.has(lineNumber)).join('\n')
+}
+
+module.exports = {
+  stripVueMarkdownWrappers,
+}

--- a/docs-site/content/.vuepress/util/markdownCopy.js
+++ b/docs-site/content/.vuepress/util/markdownCopy.js
@@ -1,6 +1,61 @@
 const MarkdownIt = require('markdown-it')
+const { COPY_LANGUAGE_OPTIONS } = require('./copyLanguages')
 
 const markdownParser = new MarkdownIt({ html: true })
+const CLIENT_LANGUAGE_TABS = COPY_LANGUAGE_OPTIONS
+const CLIENT_LANGUAGE_TAB_SET = new Set(CLIENT_LANGUAGE_TABS)
+
+function readQuotedAttribute(line, attributeName) {
+  const attributeIndex = line.indexOf(`${attributeName}=`)
+  if (attributeIndex === -1) {
+    return null
+  }
+
+  const valueStart = attributeIndex + attributeName.length + 1
+  const quote = line.charAt(valueStart)
+  if (quote !== '"' && quote !== "'") {
+    return null
+  }
+
+  const valueEnd = line.indexOf(quote, valueStart + 1)
+  if (valueEnd === -1) {
+    return null
+  }
+
+  return line.slice(valueStart + 1, valueEnd)
+}
+
+function takeUntilDelimiter(value) {
+  return [' ', '>', '/']
+    .map(delimiter => {
+      const index = value.indexOf(delimiter)
+      return index === -1 ? value.length : index
+    })
+    .reduce((smallestIndex, index) => Math.min(smallestIndex, index), value.length)
+}
+
+function parseTabsLine(line) {
+  const tabsValue = readQuotedAttribute(line, ':tabs')
+  if (!tabsValue) {
+    return []
+  }
+
+  const quote = tabsValue.includes("'") ? "'" : '"'
+
+  return tabsValue
+    .split(quote)
+    .filter((_, index) => index % 2 === 1)
+    .map(label => label.trim())
+}
+
+function parseTemplateSlotLine(line) {
+  const slotName = line.split('v-slot:')[1]
+  if (!slotName) {
+    return null
+  }
+
+  return slotName.slice(0, takeUntilDelimiter(slotName)) || null
+}
 
 function isVueMarkdownWrapperLine(line) {
   const trimmedLine = line.trim()
@@ -25,26 +80,159 @@ function isVueMarkdownWrapperLine(line) {
   return false
 }
 
-function stripVueMarkdownWrappers(markdown) {
-  const lines = markdown.split('\n')
-  const tokens = markdownParser.parse(markdown, {})
-  const linesToRemove = new Set()
+function getVueMarkdownWrapperLines(lines, tokens) {
+  const wrapperLines = new Set()
 
   tokens.forEach(token => {
     if (token.type !== 'html_block' || !token.map) {
       return
     }
 
-    for (let lineNumber = token.map[0]; lineNumber < token.map[1]; lineNumber += 1) {
+    Array.from({ length: token.map[1] - token.map[0] }, (_, offset) => token.map[0] + offset).forEach(lineNumber => {
       if (isVueMarkdownWrapperLine(lines[lineNumber])) {
-        linesToRemove.add(lineNumber)
+        wrapperLines.add(lineNumber)
       }
+    })
+  })
+
+  return wrapperLines
+}
+
+function stripVueMarkdownWrappers(markdown) {
+  const lines = markdown.split('\n')
+  const tokens = markdownParser.parse(markdown, {})
+  const wrapperLines = getVueMarkdownWrapperLines(lines, tokens)
+
+  return lines.filter((_, lineNumber) => !wrapperLines.has(lineNumber)).join('\n')
+}
+
+function getHtmlBlockLines(tokens) {
+  const htmlBlockLines = new Set()
+
+  tokens.forEach(token => {
+    if (token.type !== 'html_block' || !token.map) {
+      return
+    }
+
+    Array.from({ length: token.map[1] - token.map[0] }, (_, offset) => token.map[0] + offset).forEach(lineNumber =>
+      htmlBlockLines.add(lineNumber),
+    )
+  })
+
+  return htmlBlockLines
+}
+
+function findFirstSanitizedLine(originalToSanitizedLine, startLine, endLine) {
+  const line = originalToSanitizedLine
+    .slice(startLine, endLine)
+    .find(lineNumber => lineNumber !== -1 && lineNumber !== undefined)
+
+  return line === undefined ? null : line
+}
+
+function findLastSanitizedLine(originalToSanitizedLine, startLine, endLine) {
+  const line = originalToSanitizedLine
+    .slice(startLine, endLine)
+    .reverse()
+    .find(lineNumber => lineNumber !== -1 && lineNumber !== undefined)
+
+  return line === undefined ? null : line + 1
+}
+
+function isFilterableLanguageGroup(tabs) {
+  return tabs.length > 1 && tabs.every(tab => CLIENT_LANGUAGE_TAB_SET.has(tab))
+}
+
+function analyzeMarkdownForCopy(markdown) {
+  const lines = markdown.split('\n')
+  const tokens = markdownParser.parse(markdown, {})
+  const wrapperLines = getVueMarkdownWrapperLines(lines, tokens)
+  const htmlBlockLines = getHtmlBlockLines(tokens)
+  const originalToSanitizedLine = []
+  const sanitizedLines = []
+
+  lines.forEach((line, lineNumber) => {
+    if (wrapperLines.has(lineNumber)) {
+      originalToSanitizedLine[lineNumber] = -1
+      return
+    }
+
+    originalToSanitizedLine[lineNumber] = sanitizedLines.length
+    sanitizedLines.push(line)
+  })
+
+  const groups = []
+  let currentGroup = null
+  let currentSlot = null
+
+  lines.forEach((line, lineNumber) => {
+    if (!htmlBlockLines.has(lineNumber)) {
+      return
+    }
+
+    const trimmedLine = line.trim()
+
+    if (trimmedLine.startsWith('<Tabs')) {
+      currentGroup = {
+        tabs: parseTabsLine(trimmedLine),
+        slots: [],
+      }
+      return
+    }
+
+    if (!currentGroup) {
+      return
+    }
+
+    const slotName = parseTemplateSlotLine(trimmedLine)
+    if (slotName) {
+      currentSlot = {
+        label: slotName,
+        rawStartLine: lineNumber + 1,
+        rawEndLine: null,
+      }
+      currentGroup.slots.push(currentSlot)
+      return
+    }
+
+    if (trimmedLine === '</template>' && currentSlot) {
+      currentSlot.rawEndLine = lineNumber
+      currentSlot = null
+      return
+    }
+
+    if (trimmedLine === '</Tabs>') {
+      groups.push(currentGroup)
+      currentGroup = null
+      currentSlot = null
     }
   })
 
-  return lines.filter((_, lineNumber) => !linesToRemove.has(lineNumber)).join('\n')
+  const filterableGroups = groups
+    .filter(group => isFilterableLanguageGroup(group.tabs))
+    .map(group => ({
+      tabs: group.tabs,
+      slots: group.slots
+        .filter(slot => slot.rawEndLine !== null)
+        .map(slot => ({
+          label: slot.label,
+          startLine: findFirstSanitizedLine(originalToSanitizedLine, slot.rawStartLine, slot.rawEndLine),
+          endLine: findLastSanitizedLine(originalToSanitizedLine, slot.rawStartLine, slot.rawEndLine),
+        }))
+        .filter(slot => slot.startLine !== null && slot.endLine !== null),
+    }))
+    .filter(group => group.slots.length > 1)
+
+  return {
+    markdown: sanitizedLines.join('\n'),
+    copyTabGroups: filterableGroups,
+    copyLanguages: CLIENT_LANGUAGE_TABS.filter(language =>
+      filterableGroups.some(group => group.slots.some(slot => slot.label === language)),
+    ),
+  }
 }
 
 module.exports = {
+  analyzeMarkdownForCopy,
   stripVueMarkdownWrappers,
 }

--- a/docs-site/content/.vuepress/util/markdownCopyFilter.js
+++ b/docs-site/content/.vuepress/util/markdownCopyFilter.js
@@ -1,0 +1,77 @@
+const STORAGE_KEY = 'typesense.docs.copyMarkdownLanguages'
+const { COPY_LANGUAGE_OPTIONS } = require('./copyLanguages')
+
+function getPreferredCopyLanguages() {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    const parsedValue = value ? JSON.parse(value) : []
+    return Array.isArray(parsedValue) ? parsedValue : []
+  } catch (error) {
+    return []
+  }
+}
+
+function setPreferredCopyLanguages(languages) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(languages))
+}
+
+function markSlotLinesForRemoval(linesToRemove, slot) {
+  for (let lineNumber = slot.startLine; lineNumber < slot.endLine; lineNumber += 1) {
+    linesToRemove.add(lineNumber)
+  }
+}
+
+function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguages) {
+  if (!copyTabGroups || copyTabGroups.length === 0) {
+    return markdown
+  }
+
+  if (!selectedLanguages || selectedLanguages.length === 0) {
+    const linesToRemove = new Set()
+
+    copyTabGroups.forEach(group => {
+      group.slots.forEach(slot => markSlotLinesForRemoval(linesToRemove, slot))
+    })
+
+    return markdown
+      .split('\n')
+      .filter((_, lineNumber) => !linesToRemove.has(lineNumber))
+      .join('\n')
+  }
+
+  const selectedLanguageSet = new Set(selectedLanguages)
+  const linesToRemove = new Set()
+
+  copyTabGroups.forEach(group => {
+    const hasSelectedLanguageInGroup = group.slots.some(slot => selectedLanguageSet.has(slot.label))
+    if (!hasSelectedLanguageInGroup) {
+      return
+    }
+
+    group.slots.forEach(slot => {
+      if (!selectedLanguageSet.has(slot.label)) {
+        markSlotLinesForRemoval(linesToRemove, slot)
+      }
+    })
+  })
+
+  return markdown
+    .split('\n')
+    .filter((_, lineNumber) => !linesToRemove.has(lineNumber))
+    .join('\n')
+}
+
+module.exports = {
+  COPY_LANGUAGE_OPTIONS,
+  filterMarkdownByCopyLanguages,
+  getPreferredCopyLanguages,
+  setPreferredCopyLanguages,
+}

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -35,6 +35,7 @@
     "@dovyp/vuepress-plugin-clipboard-copy": "^1.0.0-alpha.7",
     "@vuepress/plugin-last-updated": "^1.9.7",
     "@vuepress/plugin-medium-zoom": "^1.9.7",
+    "markdown-it": "^8.4.2",
     "markdown-it-attrs": "^4.1.4",
     "prismjs": "^1.29.0",
     "vue-gtag": "^1.16.1",

--- a/docs-site/yarn.lock
+++ b/docs-site/yarn.lock
@@ -5860,7 +5860,7 @@ markdown-it-table-of-contents@^0.4.0:
   resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz#3dc7ce8b8fc17e5981c77cc398d1782319f37fbc"
   integrity sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw==
 
-markdown-it@^8.4.1:
+markdown-it@^8.4.1, markdown-it@^8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
   integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==


### PR DESCRIPTION
## Change Summary

- strip jsx (`<Tabs>` tags) from both the raw markdown and the
  sections copied
- add language-aware markdown copy controls for docs pages with tabbed
  code examples
- let users choose which languages to include when copying page or
  section markdown, and save that preference locally
  (does not work for server-served `.md` files)
- filter copied markdown to match the selected tab languages while
  skipping unavailable options and keeping them checked in the UI
- improve section copy behavior so headings inside fenced code blocks
  do not break extraction
<img width="1574" height="1110" alt="Screenshot 2026-04-30 at 17-00-49 Search Typesense" src="https://github.com/user-attachments/assets/a58ce502-1022-480e-b760-b589bb924535" />
<img width="1748" height="1034" alt="Screenshot 2026-04-30 at 17-01-06 Search Typesense" src="https://github.com/user-attachments/assets/c8923692-d92b-425c-99d9-28e727d9d3df" />
<img width="1662" height="1008" alt="Screenshot 2026-04-30 at 17-04-08 Curation Typesense" src="https://github.com/user-attachments/assets/8098075a-9d77-4226-a159-88bdd21aa5dc" />
<img width="680" height="1116" alt="Screenshot 2026-04-30 at 17-05-01 Curation Typesense" src="https://github.com/user-attachments/assets/56287793-f0c0-46a2-a5e4-563d44fb47cc" />


## PR Checklist

- [x] I have read and signed the
  [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
