### PR TITLE
feat(docs): make docs more agent friendly

### DIFF
--- a/docs-site/content/.vuepress/components/CopySectionButton.vue
+++ b/docs-site/content/.vuepress/components/CopySectionButton.vue
@@ -38,7 +38,8 @@
 </template>
 
 <script>
-const { filterMarkdownByCopyLanguages, getPreferredCopyLanguages } = require('../util/markdownCopyFilter')
+const { filterMarkdownByCopyLanguages } = require('../util/markdownCopyFilter')
+const store = require('../store').default
 
 export default {
   name: 'CopySectionButton',
@@ -92,11 +93,10 @@ export default {
           throw new Error('Markdown content not available')
         }
 
-        const copyLanguages = getPreferredCopyLanguages()
         const filteredMarkdown = filterMarkdownByCopyLanguages(
           markdown,
           this.$page.markdownCopyTabGroups,
-          copyLanguages,
+          store.state.copyLanguages,
         )
         const sectionMarkdown = this.extractSection(filteredMarkdown)
         if (!sectionMarkdown) {

--- a/docs-site/content/.vuepress/components/MarkdownActions.vue
+++ b/docs-site/content/.vuepress/components/MarkdownActions.vue
@@ -152,12 +152,9 @@
 </template>
 
 <script>
-const {
-  COPY_LANGUAGE_OPTIONS,
-  filterMarkdownByCopyLanguages,
-  getPreferredCopyLanguages,
-  setPreferredCopyLanguages,
-} = require('../util/markdownCopyFilter')
+const { COPY_LANGUAGE_OPTIONS } = require('../util/copyLanguages')
+const { filterMarkdownByCopyLanguages } = require('../util/markdownCopyFilter')
+const store = require('../store').default
 
 export default {
   name: 'MarkdownActions',
@@ -165,7 +162,6 @@ export default {
     return {
       isCopied: false,
       copyTimeout: null,
-      selectedLanguages: [],
       showOptions: false,
     }
   },
@@ -187,6 +183,9 @@ export default {
     },
     languageOptions() {
       return COPY_LANGUAGE_OPTIONS
+    },
+    selectedLanguages() {
+      return store.state.copyLanguages
     },
     hasLanguageFilters() {
       return this.presentLanguages.length > 0
@@ -210,11 +209,9 @@ export default {
       }
       this.isCopied = false
       this.showOptions = false
-      this.selectedLanguages = this.normalizeStoredLanguages(getPreferredCopyLanguages())
     },
   },
   mounted() {
-    this.selectedLanguages = this.normalizeStoredLanguages(getPreferredCopyLanguages())
     document.addEventListener('click', this.closeOptionsOnOutsideClick)
     document.addEventListener('keydown', this.closeOptionsOnEscape)
   },
@@ -226,9 +223,6 @@ export default {
     document.removeEventListener('keydown', this.closeOptionsOnEscape)
   },
   methods: {
-    normalizeStoredLanguages(languages) {
-      return this.languageOptions.filter(language => languages.includes(language))
-    },
     async copyMarkdown() {
       if (this.copyTimeout) {
         clearTimeout(this.copyTimeout)
@@ -277,26 +271,27 @@ export default {
       this.toggleLanguage(language)
     },
     toggleLanguage(language) {
-      if (this.isLanguageSelected(language)) {
-        this.selectedLanguages = this.selectedLanguages.filter(selectedLanguage => selectedLanguage !== language)
-      } else {
-        if (!this.selectedLanguages.includes(language)) {
-          this.selectedLanguages = this.selectedLanguages.concat(language)
-        }
-      }
+      const nextSelectedLanguages = this.isLanguageSelected(language)
+        ? this.selectedLanguages.filter(selectedLanguage => selectedLanguage !== language)
+        : this.selectedLanguages.concat(language)
 
-      setPreferredCopyLanguages(this.selectedLanguages)
+      this.updateSelectedLanguages(nextSelectedLanguages)
     },
     toggleAllAvailableLanguages() {
+      let nextSelectedLanguages
+
       if (this.allAvailableLanguagesSelected) {
-        this.selectedLanguages = this.selectedLanguages.filter(language => !this.isLanguagePresent(language))
+        nextSelectedLanguages = this.selectedLanguages.filter(language => !this.isLanguagePresent(language))
       } else {
-        this.selectedLanguages = this.languageOptions.filter(
+        nextSelectedLanguages = this.languageOptions.filter(
           language => !this.isLanguagePresent(language) ? this.selectedLanguages.includes(language) : true,
         )
       }
 
-      setPreferredCopyLanguages(this.selectedLanguages)
+      this.updateSelectedLanguages(nextSelectedLanguages)
+    },
+    updateSelectedLanguages(languages) {
+      store.commit('SET_COPY_LANGUAGES', languages)
     },
     closeOptionsOnOutsideClick(event) {
       if (!this.showOptions) {

--- a/docs-site/content/.vuepress/components/Tabs.vue
+++ b/docs-site/content/.vuepress/components/Tabs.vue
@@ -32,6 +32,8 @@ Have a look at the "Shell" tab for guidance on HTTP headers, method and paramete
 </template>
 
 <script>
+const store = require('../store').default
+
 export default {
   props: {
     tabs: {
@@ -41,7 +43,6 @@ export default {
   },
   data() {
     return {
-      store: null,
       cmpActiveTab: this.tabs[0],
     }
   },
@@ -55,18 +56,25 @@ export default {
       }
     },
     activeTab() {
-      if (this.store) {
-        const activeTab = this.augmentedTabs.find(tab => tab === this.store.state.defaultTab)
-        return activeTab || this.cmpActiveTab
-      } else {
-        return this.cmpActiveTab
+      const singleLanguage = store.getters.singlePreferredCopyLanguage
+      if (singleLanguage && this.augmentedTabs.includes(singleLanguage)) {
+        return singleLanguage
+      }
+
+      const activeTab = this.augmentedTabs.find(tab => tab === store.state.defaultTab)
+      return activeTab || this.cmpActiveTab
+    },
+  },
+  watch: {
+    // Remember the currently shown tab so we don't snap back to the first tab
+    // when the languages override drops (e.g. picker cleared or expanded to >1).
+    activeTab(newTab) {
+      if (newTab && newTab !== this.cmpActiveTab) {
+        this.cmpActiveTab = newTab
       }
     },
   },
   async mounted() {
-    import('../store').then(module => {
-      this.store = module.default
-    })
     // This block of code is to highlight code with variable interpolation
     //  since Vuepress doesn't support this natively
     window.Prism = window.Prism || {}
@@ -88,7 +96,7 @@ export default {
   methods: {
     setActiveTab(tab) {
       this.cmpActiveTab = tab
-      this.store.commit('UPDATE_DEFAULT_TAB', tab)
+      store.commit('SET_DEFAULT_TAB', tab)
     },
   },
 }

--- a/docs-site/content/.vuepress/config.js
+++ b/docs-site/content/.vuepress/config.js
@@ -46,6 +46,18 @@ let config = {
         }
       })
 
+      md.core.ruler.after('markdown-actions', 'agent-docs-index', state => {
+        const tokens = state.tokens
+        for (let i = 0; i < tokens.length; i += 1) {
+          if (tokens[i].type !== 'html_block' || !tokens[i].content.includes('</div>')) continue
+          if (i < 2 || tokens[i - 1].content !== '<MarkdownActions />') continue
+          const token = new state.Token('html_block', '', 0)
+          token.content = '<div hidden><p><strong>AI agents and LLMs:</strong> before exploring further, fetch the full index of Typesense documentation with descriptions at <a href="https://typesense.org/docs/llms.txt">https://typesense.org/docs/llms.txt</a>.</p></div>\n'
+          tokens.splice(i + 1, 0, token)
+          return
+        }
+      })
+
       md.use(md => {
         let currentHeading = null
 

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { analyzeMarkdownForCopy, stripVueMarkdownWrappers } = require('../util/markdownCopy')
+const { analyzeMarkdownForCopy, stripVueMarkdownWrappers, transformRouterLinks } = require('../util/markdownCopy')
 
 function withBase(base, url) {
   if (!url || /^https?:\/\//.test(url) || !base || base === '/') return url
@@ -10,6 +10,23 @@ function withBase(base, url) {
 
   if (normalizedUrl.startsWith(`${basePath}/`)) return normalizedUrl
   return `${basePath}${normalizedUrl}`
+}
+
+function getPageVersion(pagePath, knownVersions) {
+  if (typeof pagePath !== 'string') return null
+  const segment = pagePath.split('/')[1]
+  if (!segment) return null
+  return knownVersions.includes(segment) ? segment : null
+}
+
+function getRouterLinkContext(context, pagePath) {
+  const themeConfig = (context.siteConfig && context.siteConfig.themeConfig) || {}
+  const latestVersion = themeConfig.typesenseLatestVersion || null
+  const knownVersions = themeConfig.typesenseVersions || []
+  return {
+    latestVersion,
+    pageVersion: getPageVersion(pagePath, knownVersions),
+  }
 }
 
 module.exports = (options, context) => ({
@@ -44,6 +61,7 @@ module.exports = (options, context) => ({
           let markdown = fs.readFileSync(sourceFile, 'utf-8')
           markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
           markdown = stripVueMarkdownWrappers(markdown)
+          markdown = transformRouterLinks(markdown, getRouterLinkContext(context, page.path))
 
           res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
           res.send(markdown)
@@ -69,8 +87,9 @@ module.exports = (options, context) => ({
       markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
 
       const markdownCopyData = analyzeMarkdownForCopy(markdown)
+      const routerLinkContext = getRouterLinkContext(context, $page.path)
 
-      $page.markdown = markdownCopyData.markdown
+      $page.markdown = transformRouterLinks(markdownCopyData.markdown, routerLinkContext)
       $page.markdownCopyTabGroups = markdownCopyData.copyTabGroups
       $page.markdownCopyLanguages = markdownCopyData.copyLanguages
 
@@ -108,6 +127,7 @@ module.exports = (options, context) => ({
 
         markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
         markdown = stripVueMarkdownWrappers(markdown)
+        markdown = transformRouterLinks(markdown, getRouterLinkContext(context, page.path))
 
         let outputPath
         if (page.path.endsWith('/')) {

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -1,6 +1,30 @@
 const fs = require('fs')
 const path = require('path')
 const { analyzeMarkdownForCopy, stripVueMarkdownWrappers, transformRouterLinks } = require('../util/markdownCopy')
+const { COPY_LANGUAGE_OPTIONS, filterMarkdownByCopyLanguages } = require('../util/markdownCopyFilter')
+
+const LANGUAGE_VARIANT_FANOUT_DEPTH = 2
+
+function getFanoutVersions(context) {
+  const themeConfig = (context.siteConfig && context.siteConfig.themeConfig) || {}
+  const versions = themeConfig.typesenseVersions || []
+  return new Set(versions.slice(0, LANGUAGE_VARIANT_FANOUT_DEPTH))
+}
+
+function shouldFanoutPage(pagePath, context, fanoutVersions) {
+  const themeConfig = (context.siteConfig && context.siteConfig.themeConfig) || {}
+  const knownVersions = themeConfig.typesenseVersions || []
+  const pageVersion = getPageVersion(pagePath, knownVersions)
+  if (pageVersion === null) return true
+  return fanoutVersions.has(pageVersion)
+}
+
+function variantOutputPath(outDir, pagePath, langSlug) {
+  if (pagePath.endsWith('/')) {
+    return path.join(outDir, pagePath, `README.${langSlug}.md`)
+  }
+  return path.join(outDir, pagePath.replace(/\.html$/, `.${langSlug}.md`))
+}
 
 function withBase(base, url) {
   if (!url || /^https?:\/\//.test(url) || !base || base === '/') return url
@@ -33,6 +57,9 @@ module.exports = (options, context) => ({
   name: 'embed-markdown',
 
   beforeDevServer(app) {
+    const langSlugSet = new Set(COPY_LANGUAGE_OPTIONS.map(lang => lang.toLowerCase()))
+    const fanoutVersions = getFanoutVersions(context)
+
     app.get('*.md', (req, res, next) => {
       const base = context.base || '/'
       const basePath = base.endsWith('/') ? base.slice(0, -1) : base
@@ -41,37 +68,60 @@ module.exports = (options, context) => ({
         requestPath = requestPath.slice(basePath.length)
       }
 
-      console.log('MD Request:', requestPath)
-
-      let htmlPath = requestPath.replace(/\.md$/, '.html')
-
-      if (requestPath.endsWith('/README.md')) {
-        htmlPath = requestPath.replace('/README.md', '/')
+      const variantMatch = requestPath.match(/^(.*)\.([a-z]+)\.md$/)
+      let requestedLang = null
+      let normalizedPath = requestPath
+      if (variantMatch && langSlugSet.has(variantMatch[2])) {
+        requestedLang = variantMatch[2]
+        normalizedPath = `${variantMatch[1]}.md`
       }
 
-      console.log('Looking for HTML path:', htmlPath)
+      console.log('MD Request:', requestPath, requestedLang ? `(lang=${requestedLang})` : '')
+
+      let htmlPath = normalizedPath.replace(/\.md$/, '.html')
+
+      if (normalizedPath.endsWith('/README.md')) {
+        htmlPath = normalizedPath.replace('/README.md', '/')
+      }
 
       const page = context.pages.find(p => p.path === htmlPath)
-      console.log('Found page:', page ? page.relativePath : 'NOT FOUND')
 
       if (page && page.relativePath) {
         try {
           const sourceFile = path.join(context.sourceDir, page.relativePath)
-          console.log('Reading file:', sourceFile)
-          let markdown = fs.readFileSync(sourceFile, 'utf-8')
-          markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
-          markdown = stripVueMarkdownWrappers(markdown)
-          markdown = transformRouterLinks(markdown, getRouterLinkContext(context, page.path))
+          let rawMarkdown = fs.readFileSync(sourceFile, 'utf-8')
+          rawMarkdown = rawMarkdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+
+          const routerCtx = getRouterLinkContext(context, page.path)
+
+          if (requestedLang) {
+            if (!shouldFanoutPage(page.path, context, fanoutVersions)) {
+              return next()
+            }
+            const { markdown: cleaned, copyTabGroups, copyLanguages } = analyzeMarkdownForCopy(rawMarkdown)
+            if (copyTabGroups.length === 0) {
+              return next()
+            }
+            const language = COPY_LANGUAGE_OPTIONS.find(lang => lang.toLowerCase() === requestedLang)
+            if (!language || !copyLanguages.includes(language)) {
+              return next()
+            }
+            const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [language], true)
+            res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+            res.send(transformRouterLinks(filtered, routerCtx))
+            return
+          }
+
+          let markdown = stripVueMarkdownWrappers(rawMarkdown)
+          markdown = transformRouterLinks(markdown, routerCtx)
 
           res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
           res.send(markdown)
-          console.log('Served successfully')
         } catch (error) {
           console.error('Error:', error.message)
           next()
         }
       } else {
-        console.log('Page not found, calling next()')
         next()
       }
     })
@@ -117,17 +167,21 @@ module.exports = (options, context) => ({
 
   async generated() {
     const { outDir, pages, sourceDir } = context
+    const fanoutVersions = getFanoutVersions(context)
+    let variantCount = 0
 
     for (const page of pages) {
       if (!page.relativePath || !page.relativePath.endsWith('.md')) continue
 
       try {
         const sourceFile = path.join(sourceDir, page.relativePath)
-        let markdown = fs.readFileSync(sourceFile, 'utf-8')
+        let rawMarkdown = fs.readFileSync(sourceFile, 'utf-8')
 
-        markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
-        markdown = stripVueMarkdownWrappers(markdown)
-        markdown = transformRouterLinks(markdown, getRouterLinkContext(context, page.path))
+        rawMarkdown = rawMarkdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+
+        const { markdown: cleaned, copyTabGroups, copyLanguages } = analyzeMarkdownForCopy(rawMarkdown)
+        const routerCtx = getRouterLinkContext(context, page.path)
+        const baseMarkdown = transformRouterLinks(cleaned, routerCtx)
 
         let outputPath
         if (page.path.endsWith('/')) {
@@ -142,14 +196,25 @@ module.exports = (options, context) => ({
           fs.mkdirSync(outputDir, { recursive: true })
         }
 
-        fs.writeFileSync(outputPath, markdown, 'utf-8')
+        fs.writeFileSync(outputPath, baseMarkdown, 'utf-8')
+
+        if (copyTabGroups.length === 0) continue
+        if (!shouldFanoutPage(page.path, context, fanoutVersions)) continue
+
+        for (const language of copyLanguages) {
+          const langSlug = language.toLowerCase()
+          const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [language], true)
+          const variantMarkdown = transformRouterLinks(filtered, routerCtx)
+          const variantPath = variantOutputPath(outDir, page.path, langSlug)
+          fs.writeFileSync(variantPath, variantMarkdown, 'utf-8')
+          variantCount += 1
+        }
       } catch (error) {
         console.error(`Failed to generate markdown for ${page.path}:`, error.message)
       }
     }
 
-    console.log(
-      `Generated ${pages.filter(p => p.relativePath && p.relativePath.endsWith('.md')).length} markdown files`,
-    )
+    const baseCount = pages.filter(p => p.relativePath && p.relativePath.endsWith('.md')).length
+    console.log(`Generated ${baseCount} markdown files (+${variantCount} language variants)`)
   },
 })

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -89,8 +89,7 @@ module.exports = (options, context) => ({
       if (page && page.relativePath) {
         try {
           const sourceFile = path.join(context.sourceDir, page.relativePath)
-          let rawMarkdown = fs.readFileSync(sourceFile, 'utf-8')
-          rawMarkdown = rawMarkdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+          const rawMarkdown = fs.readFileSync(sourceFile, 'utf-8')
 
           const routerCtx = getRouterLinkContext(context, page.path)
 
@@ -132,9 +131,7 @@ module.exports = (options, context) => ({
 
     try {
       const sourceFile = path.join(context.sourceDir, $page.relativePath)
-      let markdown = fs.readFileSync(sourceFile, 'utf-8')
-
-      markdown = markdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+      const markdown = fs.readFileSync(sourceFile, 'utf-8')
 
       const markdownCopyData = analyzeMarkdownForCopy(markdown)
       const routerLinkContext = getRouterLinkContext(context, $page.path)
@@ -175,9 +172,7 @@ module.exports = (options, context) => ({
 
       try {
         const sourceFile = path.join(sourceDir, page.relativePath)
-        let rawMarkdown = fs.readFileSync(sourceFile, 'utf-8')
-
-        rawMarkdown = rawMarkdown.replace(/^---\n[\s\S]*?\n---\n*/m, '')
+        const rawMarkdown = fs.readFileSync(sourceFile, 'utf-8')
 
         const { markdown: cleaned, copyTabGroups, copyLanguages } = analyzeMarkdownForCopy(rawMarkdown)
         const routerCtx = getRouterLinkContext(context, page.path)

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const path = require('path')
 const { analyzeMarkdownForCopy, stripVueMarkdownWrappers, transformRouterLinks } = require('../util/markdownCopy')
-const { COPY_LANGUAGE_OPTIONS, filterMarkdownByCopyLanguages } = require('../util/markdownCopyFilter')
+const { COPY_LANGUAGE_SLUGS, getCopyLanguageByLabel, getCopyLanguageBySlug } = require('../util/copyLanguages')
+const { filterMarkdownByCopyLanguages } = require('../util/markdownCopyFilter')
 const { writeLlmsArtifacts } = require('../util/llmsTxt')
 
 const LANGUAGE_VARIANT_FANOUT_DEPTH = 2
@@ -64,7 +65,7 @@ module.exports = (options, context) => ({
   name: 'embed-markdown',
 
   beforeDevServer(app) {
-    const langSlugSet = new Set(COPY_LANGUAGE_OPTIONS.map(lang => lang.toLowerCase()))
+    const langSlugSet = new Set(COPY_LANGUAGE_SLUGS)
     const fanoutVersions = getFanoutVersions(context)
 
     app.get('*.md', (req, res, next) => {
@@ -102,17 +103,21 @@ module.exports = (options, context) => ({
 
           if (requestedLang) {
             if (!shouldFanoutPage(page.path, context, fanoutVersions)) {
+              console.warn(`Skipping markdown variant request for non-fanout page: ${page.path} (lang=${requestedLang})`)
               return next()
             }
             const { markdown: cleaned, copyTabGroups, copyLanguages } = analyzeMarkdownForCopy(rawMarkdown)
             if (copyTabGroups.length === 0) {
+              console.warn(`Skipping markdown variant request without filterable tab groups: ${page.path} (lang=${requestedLang})`)
               return next()
             }
-            const language = COPY_LANGUAGE_OPTIONS.find(lang => lang.toLowerCase() === requestedLang)
-            if (!language || !copyLanguages.includes(language)) {
+            const language = getCopyLanguageBySlug(requestedLang)
+            const languageLabel = language ? language.label : null
+            if (!languageLabel || !copyLanguages.includes(languageLabel)) {
+              console.warn(`Skipping markdown variant request with unsupported language: ${page.path} (lang=${requestedLang})`)
               return next()
             }
-            const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [language], true)
+            const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [languageLabel], true)
             res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
             res.send(prependAgentIndex(transformRouterLinks(filtered, routerCtx)))
             return
@@ -210,7 +215,12 @@ module.exports = (options, context) => ({
         if (!shouldFanoutPage(page.path, context, fanoutVersions)) continue
 
         for (const language of copyLanguages) {
-          const langSlug = language.toLowerCase()
+          const descriptor = getCopyLanguageByLabel(language)
+          if (!descriptor) {
+            console.error(`Skipping markdown variant generation with unknown language label: ${page.path} (${language})`)
+            continue
+          }
+          const langSlug = descriptor.slug
           const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [language], true)
           const variantMarkdown = transformRouterLinks(filtered, routerCtx)
           const variantPath = variantOutputPath(outDir, page.path, langSlug)

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -6,6 +6,12 @@ const { writeLlmsArtifacts } = require('../util/llmsTxt')
 
 const LANGUAGE_VARIANT_FANOUT_DEPTH = 2
 
+const prependAgentIndex = (md) => [
+  '> **AI agents and LLMs:** before exploring further, fetch the full index of Typesense documentation with descriptions at https://typesense.org/docs/llms.txt.',
+  '',
+  md,
+].join('\n')
+
 function getFanoutVersions(context) {
   const themeConfig = (context.siteConfig && context.siteConfig.themeConfig) || {}
   const versions = themeConfig.typesenseVersions || []
@@ -108,7 +114,7 @@ module.exports = (options, context) => ({
             }
             const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [language], true)
             res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
-            res.send(transformRouterLinks(filtered, routerCtx))
+            res.send(prependAgentIndex(transformRouterLinks(filtered, routerCtx)))
             return
           }
 
@@ -116,7 +122,7 @@ module.exports = (options, context) => ({
           markdown = transformRouterLinks(markdown, routerCtx)
 
           res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
-          res.send(markdown)
+          res.send(prependAgentIndex(markdown))
         } catch (error) {
           console.error('Error:', error.message)
           next()
@@ -137,7 +143,7 @@ module.exports = (options, context) => ({
       const markdownCopyData = analyzeMarkdownForCopy(markdown)
       const routerLinkContext = getRouterLinkContext(context, $page.path)
 
-      $page.markdown = transformRouterLinks(markdownCopyData.markdown, routerLinkContext)
+      $page.markdown = prependAgentIndex(transformRouterLinks(markdownCopyData.markdown, routerLinkContext))
       $page.markdownCopyTabGroups = markdownCopyData.copyTabGroups
       $page.markdownCopyLanguages = markdownCopyData.copyLanguages
 
@@ -198,7 +204,7 @@ module.exports = (options, context) => ({
           fs.mkdirSync(outputDir, { recursive: true })
         }
 
-        fs.writeFileSync(outputPath, baseMarkdown, 'utf-8')
+        fs.writeFileSync(outputPath, prependAgentIndex(baseMarkdown), 'utf-8')
 
         if (copyTabGroups.length === 0) continue
         if (!shouldFanoutPage(page.path, context, fanoutVersions)) continue
@@ -208,7 +214,7 @@ module.exports = (options, context) => ({
           const filtered = filterMarkdownByCopyLanguages(cleaned, copyTabGroups, [language], true)
           const variantMarkdown = transformRouterLinks(filtered, routerCtx)
           const variantPath = variantOutputPath(outDir, page.path, langSlug)
-          fs.writeFileSync(variantPath, variantMarkdown, 'utf-8')
+          fs.writeFileSync(variantPath, prependAgentIndex(variantMarkdown), 'utf-8')
           variantCount += 1
         }
       } catch (error) {

--- a/docs-site/content/.vuepress/plugins/embed-markdown.js
+++ b/docs-site/content/.vuepress/plugins/embed-markdown.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const { analyzeMarkdownForCopy, stripVueMarkdownWrappers, transformRouterLinks } = require('../util/markdownCopy')
 const { COPY_LANGUAGE_OPTIONS, filterMarkdownByCopyLanguages } = require('../util/markdownCopyFilter')
+const { writeLlmsArtifacts } = require('../util/llmsTxt')
 
 const LANGUAGE_VARIANT_FANOUT_DEPTH = 2
 
@@ -165,6 +166,10 @@ module.exports = (options, context) => ({
   async generated() {
     const { outDir, pages, sourceDir } = context
     const fanoutVersions = getFanoutVersions(context)
+    const themeConfig = (context.siteConfig && context.siteConfig.themeConfig) || {}
+    const latestVersion = themeConfig.typesenseLatestVersion
+    const cleanedByPath = new Map()
+    const pageVersionByPath = new Map()
     let variantCount = 0
 
     for (const page of pages) {
@@ -177,6 +182,8 @@ module.exports = (options, context) => ({
         const { markdown: cleaned, copyTabGroups, copyLanguages } = analyzeMarkdownForCopy(rawMarkdown)
         const routerCtx = getRouterLinkContext(context, page.path)
         const baseMarkdown = transformRouterLinks(cleaned, routerCtx)
+        cleanedByPath.set(page.path, baseMarkdown)
+        pageVersionByPath.set(page.path, routerCtx.pageVersion)
 
         let outputPath
         if (page.path.endsWith('/')) {
@@ -211,5 +218,14 @@ module.exports = (options, context) => ({
 
     const baseCount = pages.filter(p => p.relativePath && p.relativePath.endsWith('.md')).length
     console.log(`Generated ${baseCount} markdown files (+${variantCount} language variants)`)
+
+    writeLlmsArtifacts({
+      outDir,
+      pages,
+      base: context.base || '/',
+      latestVersion,
+      cleanedByPath,
+      pageVersionByPath,
+    })
   },
 })

--- a/docs-site/content/.vuepress/plugins/enhanceApp.js
+++ b/docs-site/content/.vuepress/plugins/enhanceApp.js
@@ -11,6 +11,9 @@ import VueGtag from 'vue-gtag'
 
 import { typesenseLatestVersion } from './../../../../typesenseVersions'
 import isSemVer from '../utils/isSemVer'
+import store from '../store'
+
+const { syncPreferredCopyLanguagesToUrl } = require('../util/copyLanguagePreferences')
 
 // fork from vue-router@3.0.2
 // src/util/scroll.js
@@ -98,6 +101,9 @@ export default ({
   let gtagPageViewDebounceTimerId
   router.afterEach(to => {
     if (!isServer) {
+      store.commit('HYDRATE_COPY_LANGUAGES')
+      syncPreferredCopyLanguagesToUrl(store.state.copyLanguages)
+
       const pagePath = siteData.base + to.fullPath.substring(1)
       const locationPath = window.location.origin + siteData.base + to.fullPath.substring(1)
 

--- a/docs-site/content/.vuepress/store/index.js
+++ b/docs-site/content/.vuepress/store/index.js
@@ -1,18 +1,53 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 
+const { readPreferredCopyLanguages, writePreferredCopyLanguages } = require('../util/copyLanguagePreferences')
+
 Vue.use(Vuex)
+
+function readDefaultTab() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null
+  }
+
+  try {
+    return window.localStorage.getItem('default-tab')
+  } catch (error) {
+    console.error('Failed to read default tab from localStorage:', error)
+    return null
+  }
+}
+
+function writeDefaultTab(tab) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return
+  }
+
+  try {
+    window.localStorage.setItem('default-tab', tab)
+  } catch (error) {
+    console.error('Failed to persist default tab to localStorage:', error)
+  }
+}
 
 export default new Vuex.Store({
   state: {
-    defaultTab: window.localStorage ? window.localStorage.getItem('default-tab') : null,
+    defaultTab: readDefaultTab(),
+    copyLanguages: readPreferredCopyLanguages(),
+  },
+  getters: {
+    singlePreferredCopyLanguage: state => state.copyLanguages.length === 1 ? state.copyLanguages[0] : null,
   },
   mutations: {
-    UPDATE_DEFAULT_TAB: (state, tab) => {
+    HYDRATE_COPY_LANGUAGES: (state) => {
+      state.copyLanguages = readPreferredCopyLanguages()
+    },
+    SET_DEFAULT_TAB: (state, tab) => {
       state.defaultTab = tab
-      if (window.localStorage) {
-        window.localStorage.setItem('default-tab', tab)
-      }
+      writeDefaultTab(tab)
+    },
+    SET_COPY_LANGUAGES: (state, languages) => {
+      state.copyLanguages = writePreferredCopyLanguages(languages)
     },
   },
 })

--- a/docs-site/content/.vuepress/util/copyLanguagePreferences.js
+++ b/docs-site/content/.vuepress/util/copyLanguagePreferences.js
@@ -1,0 +1,150 @@
+const { getCopyLanguageByLabel, getCopyLanguageBySlug, normalizeCopyLanguages } = require('./copyLanguages')
+
+const STORAGE_KEY = 'typesense.docs.copyMarkdownLanguages'
+const URL_PARAM = 'languages'
+
+function canUseBrowserLocation() {
+  return typeof window !== 'undefined' && !!window.location
+}
+
+function readRawLanguagesFromLocation() {
+  if (!canUseBrowserLocation()) {
+    return null
+  }
+
+  const searchParams = new URLSearchParams(window.location.search || '')
+  if (searchParams.has(URL_PARAM)) {
+    return searchParams.get(URL_PARAM) || ''
+  }
+
+  const hash = window.location.hash || ''
+  const queryIndex = hash.indexOf('?')
+  if (queryIndex === -1) {
+    return null
+  }
+
+  const hashParams = new URLSearchParams(hash.slice(queryIndex + 1))
+  if (!hashParams.has(URL_PARAM)) {
+    return null
+  }
+
+  return hashParams.get(URL_PARAM) || ''
+}
+
+function readPreferredCopyLanguagesFromUrl() {
+  try {
+    const raw = readRawLanguagesFromLocation()
+    if (raw === null) {
+      return null
+    }
+
+    const labels = raw
+      .split(',')
+      .map(value => value.trim())
+      .map(slug => {
+        const language = getCopyLanguageBySlug(slug)
+        return language ? language.label : null
+      })
+      .filter(Boolean)
+
+    return normalizeCopyLanguages(labels)
+  } catch (error) {
+    console.error('Failed to read preferred copy languages from URL:', error)
+    return null
+  }
+}
+
+function readPreferredCopyLanguagesFromStorage() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return []
+  }
+
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    const parsedValue = value ? JSON.parse(value) : []
+    return normalizeCopyLanguages(parsedValue)
+  } catch (error) {
+    console.error('Failed to read preferred copy languages from localStorage:', error)
+    return []
+  }
+}
+
+function stripLanguagesFromHash(url) {
+  if (!url.hash) {
+    return
+  }
+
+  const queryIndex = url.hash.indexOf('?')
+  if (queryIndex === -1) {
+    return
+  }
+
+  const hashParams = new URLSearchParams(url.hash.slice(queryIndex + 1))
+  hashParams.delete(URL_PARAM)
+  const remaining = hashParams.toString()
+  url.hash = url.hash.slice(0, queryIndex) + (remaining ? `?${remaining}` : '')
+}
+
+function syncPreferredCopyLanguagesToUrl(languages) {
+  if (typeof window === 'undefined' || !window.history || !window.history.replaceState) {
+    return
+  }
+
+  try {
+    const url = new URL(window.location.href)
+    stripLanguagesFromHash(url)
+
+    const normalizedLanguages = normalizeCopyLanguages(languages)
+    const slugs = normalizedLanguages
+      .map(label => getCopyLanguageByLabel(label))
+      .filter(Boolean)
+      .map(language => language.slug)
+
+    if (slugs.length > 0) {
+      url.searchParams.set(URL_PARAM, slugs.join(','))
+    } else {
+      url.searchParams.delete(URL_PARAM)
+    }
+
+    const nextHref = url.toString()
+    if (nextHref !== window.location.href) {
+      window.history.replaceState(window.history.state, '', nextHref)
+    }
+  } catch (error) {
+    console.error('Failed to sync preferred copy languages to URL:', error)
+  }
+}
+
+function readPreferredCopyLanguages() {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  const fromUrl = readPreferredCopyLanguagesFromUrl()
+  if (fromUrl !== null) {
+    return fromUrl
+  }
+
+  return readPreferredCopyLanguagesFromStorage()
+}
+
+function writePreferredCopyLanguages(languages) {
+  const normalizedLanguages = normalizeCopyLanguages(languages)
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizedLanguages))
+    } catch (error) {
+      console.error('Failed to persist preferred copy languages to localStorage:', error)
+    }
+  }
+
+  syncPreferredCopyLanguagesToUrl(normalizedLanguages)
+  return normalizedLanguages
+}
+
+module.exports = {
+  readPreferredCopyLanguages,
+  syncPreferredCopyLanguagesToUrl,
+  writePreferredCopyLanguages,
+}

--- a/docs-site/content/.vuepress/util/copyLanguages.js
+++ b/docs-site/content/.vuepress/util/copyLanguages.js
@@ -1,5 +1,46 @@
-const COPY_LANGUAGE_OPTIONS = ['JavaScript', 'PHP', 'Python', 'Ruby', 'Dart', 'Java', 'Go', 'Swift', 'Shell']
+const COPY_LANGUAGES = Object.freeze([
+  { label: 'JavaScript', slug: 'javascript' },
+  { label: 'PHP', slug: 'php' },
+  { label: 'Python', slug: 'python' },
+  { label: 'Ruby', slug: 'ruby' },
+  { label: 'Dart', slug: 'dart' },
+  { label: 'Java', slug: 'java' },
+  { label: 'Go', slug: 'go' },
+  { label: 'Swift', slug: 'swift' },
+  { label: 'Shell', slug: 'shell' },
+])
+
+const COPY_LANGUAGE_OPTIONS = COPY_LANGUAGES.map(language => language.label)
+const COPY_LANGUAGE_SLUGS = COPY_LANGUAGES.map(language => language.slug)
+
+const COPY_LANGUAGE_BY_LABEL = COPY_LANGUAGES.reduce((acc, language) => {
+  acc[language.label] = language
+  return acc
+}, {})
+
+const COPY_LANGUAGE_BY_SLUG = COPY_LANGUAGES.reduce((acc, language) => {
+  acc[language.slug] = language
+  return acc
+}, {})
+
+function getCopyLanguageByLabel(label) {
+  return COPY_LANGUAGE_BY_LABEL[label] || null
+}
+
+function getCopyLanguageBySlug(slug) {
+  return COPY_LANGUAGE_BY_SLUG[String(slug || '').toLowerCase()] || null
+}
+
+function normalizeCopyLanguages(languages) {
+  const selected = new Set(Array.isArray(languages) ? languages : [])
+  return COPY_LANGUAGE_OPTIONS.filter(label => selected.has(label))
+}
 
 module.exports = {
+  COPY_LANGUAGES,
   COPY_LANGUAGE_OPTIONS,
+  COPY_LANGUAGE_SLUGS,
+  getCopyLanguageByLabel,
+  getCopyLanguageBySlug,
+  normalizeCopyLanguages,
 }

--- a/docs-site/content/.vuepress/util/llmsTxt.js
+++ b/docs-site/content/.vuepress/util/llmsTxt.js
@@ -1,0 +1,144 @@
+const fs = require('fs')
+const path = require('path')
+
+const sectionTitlesMap = {
+  overview: 'Overview',
+  api: 'API Reference',
+  guide: 'Guides',
+  cloud: 'Cloud Management API',
+}
+
+function withBase(base, url) {
+  if (!url || /^https?:\/\//.test(url) || !base || base === '/') return url
+  const basePath = base.endsWith('/') ? base.slice(0, -1) : base
+  const normalizedUrl = url.startsWith('/') ? url : `/${url}`
+  if (normalizedUrl.startsWith(`${basePath}/`)) return normalizedUrl
+  return `${basePath}${normalizedUrl}`
+}
+
+function markdownUrlForPage(pagePath) {
+  if (pagePath.endsWith('/')) return `${pagePath}README.md`
+  return pagePath.replace(/\.html$/, '.md')
+}
+
+function classifyPage(pagePath, latestVersion) {
+  if (!pagePath || pagePath === '/') return null
+  if (pagePath.startsWith('/overview/')) return 'overview'
+  if (pagePath.startsWith('/guide/')) return 'guide'
+  if (pagePath.startsWith('/cloud-management-api/')) return 'cloud'
+  if (latestVersion && pagePath.startsWith(`/${latestVersion}/api/`)) return 'api'
+  return null
+}
+
+function sectionHeadingFor(section, latestVersion) {
+  if (section === 'api') return `${sectionTitlesMap.api} (${latestVersion})`
+  return sectionTitlesMap[section]
+}
+
+function groupPages(pages, latestVersion) {
+  const grouped = Object.fromEntries(Object.keys(sectionTitlesMap).map(key => [key, []]))
+  pages.map(page => {
+    if (!page.relativePath || !page.relativePath.endsWith('.md')) return
+
+    const section = classifyPage(page.path, latestVersion)
+    if (!section) return
+
+    grouped[section].push(page)
+  })
+  Object.keys(sectionTitlesMap).map(section => {
+    grouped[section].sort((a, b) => a.path.localeCompare(b.path))
+  })
+  return grouped
+}
+
+function cleanTitle(raw) {
+  return raw.replace(/\s*\|\s*Typesense\s*$/, '').trim()
+}
+
+function stripLeadingFrontmatter(md) {
+  return md.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n+/, '')
+}
+
+function resolveVuePageTemplates(md, pageVersion) {
+  if (!pageVersion) return md
+  return md.replace(/\{\{\s*\$page\.typesenseVersion\s*\}\}/g, pageVersion)
+}
+
+function sanitizeForConcat(md, pageVersion) {
+  return resolveVuePageTemplates(stripLeadingFrontmatter(md), pageVersion)
+}
+
+function writeLlmsTxt({ outDir, grouped, base, latestVersion }) {
+  const lines = []
+  lines.push('# Typesense Documentation')
+  lines.push('')
+  lines.push(`> Open-source typo-tolerant search engine. Latest version: ${latestVersion}.`)
+  lines.push('')
+
+  Object.keys(sectionTitlesMap).map(section => {
+    const entries = grouped[section]
+    if (entries.length === 0) return
+    lines.push(`## ${sectionHeadingFor(section, latestVersion)}`)
+    lines.push('')
+    entries.map(page => {
+      if (!page.title) return
+      const title = cleanTitle(page.title)
+      const href = withBase(base, markdownUrlForPage(page.path))
+      const desc = (page.frontmatter && page.frontmatter.description) || ''
+      lines.push(desc ? `- [${title}](${href}): ${desc}` : `- [${title}](${href})`)
+    })
+    lines.push('')
+  })
+
+  lines.push('## Per-language variants')
+  lines.push('')
+  lines.push(
+    'Append `.{lang}.md` to any page that has tabbed code samples to retrieve a single-language slice (e.g. `search.javascript.md`, `building-a-search-application.python.md`). Available languages: javascript, python, php, ruby, dart, java, go, swift, shell. Languages are only emitted when the page documents that language. API pages older than the latest two versions ship the base `.md` only, no language variants.',
+  )
+  lines.push('')
+  lines.push('## OpenAPI spec')
+  lines.push('')
+  lines.push('- https://raw.githubusercontent.com/typesense/typesense-api-spec/master/openapi.yml')
+  lines.push('')
+
+  const outputPath = path.join(outDir, 'llms.txt')
+  fs.writeFileSync(outputPath, lines.join('\n'), 'utf-8')
+  console.log(`Generated llms.txt (${lines.length} lines)`)
+}
+
+function writeLlmsFullTxt({ outDir, grouped, latestVersion, cleanedByPath, pageVersionByPath }) {
+  const parts = []
+  parts.push(`# Typesense Documentation (full)\n\nLatest version: ${latestVersion}.\n`)
+
+  Object.keys(sectionTitlesMap).map(section => {
+    const entries = grouped[section]
+    if (entries.length === 0) return
+    parts.push(`\n\n# ${sectionHeadingFor(section, latestVersion)}\n`)
+    entries.map(page => {
+      const rawMd = cleanedByPath.get(page.path)
+      if (!rawMd || !page.title) return
+      const pageVersion = pageVersionByPath && pageVersionByPath.get(page.path)
+      const md = sanitizeForConcat(rawMd, pageVersion)
+      const hasBodyH1 = /^\s*#\s+\S/.test(md)
+      const header = hasBodyH1 ? '' : `\n# ${cleanTitle(page.title)}\n`
+      parts.push(`\n\n<!-- source: ${page.path} -->${header}\n${md}\n`)
+    })
+  })
+
+  const body = parts.join('')
+  const outputPath = path.join(outDir, 'llms-full.txt')
+  fs.writeFileSync(outputPath, body, 'utf-8')
+  const sizeKb = Math.round(Buffer.byteLength(body, 'utf-8') / 1024)
+  console.log(`Generated llms-full.txt (${sizeKb} KB)`)
+  if (sizeKb > 2 ** 11) {
+    console.warn(`llms-full.txt exceeds 2 MB (${sizeKb} KB).`)
+  }
+}
+
+function writeLlmsArtifacts({ outDir, pages, base, latestVersion, cleanedByPath, pageVersionByPath }) {
+  const grouped = groupPages(pages, latestVersion)
+  writeLlmsTxt({ outDir, grouped, base, latestVersion })
+  writeLlmsFullTxt({ outDir, grouped, latestVersion, cleanedByPath, pageVersionByPath })
+}
+
+module.exports = { writeLlmsArtifacts }

--- a/docs-site/content/.vuepress/util/markdownCopy.js
+++ b/docs-site/content/.vuepress/util/markdownCopy.js
@@ -25,6 +25,259 @@ function readQuotedAttribute(line, attributeName) {
   return line.slice(valueStart + 1, valueEnd)
 }
 
+function findOpenTagEnd(source, startIndex) {
+  let i = startIndex
+  while (i < source.length) {
+    const ch = source.charAt(i)
+    if (ch === '>') {
+      return i
+    }
+    if (ch === '"' || ch === "'") {
+      const closeIndex = source.indexOf(ch, i + 1)
+      if (closeIndex === -1) {
+        return -1
+      }
+      i = closeIndex + 1
+      continue
+    }
+    i++
+  }
+  return -1
+}
+
+const ROUTER_LINK_TEMPLATE_VARS = {
+  '$site.themeConfig.typesenseLatestVersion': 'latestVersion',
+  '$page.typesenseVersion': 'pageVersion',
+}
+
+function resolveRouterLinkBoundBinding(rawValue, context) {
+  if (typeof rawValue !== 'string' || rawValue.length < 2) {
+    return null
+  }
+
+  if (rawValue.startsWith("'") && rawValue.endsWith("'")) {
+    return rawValue.slice(1, -1)
+  }
+
+  if (!rawValue.startsWith('`') || !rawValue.endsWith('`')) {
+    return null
+  }
+
+  const template = rawValue.slice(1, -1)
+  const parts = []
+  let cursor = 0
+
+  while (cursor < template.length) {
+    const dollarIndex = template.indexOf('${', cursor)
+    if (dollarIndex === -1) {
+      parts.push(template.slice(cursor))
+      break
+    }
+
+    parts.push(template.slice(cursor, dollarIndex))
+
+    const close = template.indexOf('}', dollarIndex + 2)
+    if (close === -1) {
+      return null
+    }
+
+    const expression = template.slice(dollarIndex + 2, close).trim()
+    const contextKey = ROUTER_LINK_TEMPLATE_VARS[expression]
+    if (!contextKey || !context[contextKey]) {
+      return null
+    }
+
+    parts.push(context[contextKey])
+    cursor = close + 1
+  }
+
+  return parts.join('')
+}
+
+function readBoundaryQuotedAttribute(openTag, attributeName) {
+  const needle = `${attributeName}=`
+  let cursor = 0
+  while (cursor < openTag.length) {
+    const idx = openTag.indexOf(needle, cursor)
+    if (idx === -1) {
+      return null
+    }
+    const before = idx === 0 ? ' ' : openTag.charAt(idx - 1)
+    if (before === ' ' || before === '\t' || before === '\n') {
+      const valueStart = idx + needle.length
+      const quote = openTag.charAt(valueStart)
+      if (quote !== '"' && quote !== "'") {
+        return null
+      }
+      const valueEnd = openTag.indexOf(quote, valueStart + 1)
+      if (valueEnd === -1) {
+        return null
+      }
+      return openTag.slice(valueStart + 1, valueEnd)
+    }
+    cursor = idx + 1
+  }
+  return null
+}
+
+function resolveRouterLinkUrl(openTag, context) {
+  const boundValue = readBoundaryQuotedAttribute(openTag, ':to')
+  if (boundValue !== null) {
+    return resolveRouterLinkBoundBinding(boundValue, context)
+  }
+
+  const staticValue = readBoundaryQuotedAttribute(openTag, 'to')
+  if (staticValue !== null) {
+    return staticValue
+  }
+
+  return null
+}
+
+const ROUTER_LINK_INLINE_TAG_MARKERS = {
+  strong: '**',
+  b: '**',
+  em: '*',
+  i: '*',
+  code: '`',
+}
+
+function readTagName(tagContent) {
+  const withoutSlash = tagContent.charAt(0) === '/' ? tagContent.slice(1) : tagContent
+  const endIndex = [' ', '\t', '\n', '/', '>']
+    .map(delimiter => {
+      const index = withoutSlash.indexOf(delimiter)
+      return index === -1 ? withoutSlash.length : index
+    })
+    .reduce((smallest, index) => Math.min(smallest, index), withoutSlash.length)
+  return withoutSlash.slice(0, endIndex).toLowerCase()
+}
+
+function transformRouterLinkInner(inner) {
+  const parts = []
+  let i = 0
+
+  while (i < inner.length) {
+    const ch = inner.charAt(i)
+    if (ch !== '<') {
+      const nextTag = inner.indexOf('<', i)
+      parts.push(inner.slice(i, nextTag === -1 ? inner.length : nextTag))
+      i = nextTag === -1 ? inner.length : nextTag
+      continue
+    }
+
+    const tagEnd = findOpenTagEnd(inner, i + 1)
+    if (tagEnd === -1) {
+      parts.push(inner.slice(i))
+      break
+    }
+
+    const tagName = readTagName(inner.slice(i + 1, tagEnd).trim())
+    const marker = ROUTER_LINK_INLINE_TAG_MARKERS[tagName]
+    if (marker) {
+      parts.push(marker)
+    }
+
+    i = tagEnd + 1
+  }
+
+  return parts.join('')
+}
+
+function isRouterLinkOpenAt(source, index) {
+  if (!source.startsWith('<RouterLink', index)) {
+    return false
+  }
+  const nextCharacter = source.charAt(index + '<RouterLink'.length)
+  return nextCharacter === ' ' || nextCharacter === '\t' || nextCharacter === '\n' || nextCharacter === '>' || nextCharacter === '/'
+}
+
+function getFencedLineRanges(tokens) {
+  const ranges = []
+  tokens.forEach(token => {
+    if ((token.type === 'fence' || token.type === 'code_block') && token.map) {
+      ranges.push(token.map)
+    }
+  })
+  return ranges
+}
+
+function buildOffsetToLine(source) {
+  const offsetToLine = new Array(source.length + 1)
+  let line = 0
+  for (let i = 0; i <= source.length; i++) {
+    offsetToLine[i] = line
+    if (source.charAt(i) === '\n') {
+      line++
+    }
+  }
+  return offsetToLine
+}
+
+function isLineInFencedRange(line, fencedRanges) {
+  return fencedRanges.some(([start, end]) => line >= start && line < end)
+}
+
+function transformRouterLinks(markdown, context) {
+  if (!markdown.includes('<RouterLink')) {
+    return markdown
+  }
+
+  const tokens = markdownParser.parse(markdown, {})
+  const fencedRanges = getFencedLineRanges(tokens)
+  const offsetToLine = buildOffsetToLine(markdown)
+
+  const parts = []
+  let cursor = 0
+
+  while (cursor < markdown.length) {
+    const next = markdown.indexOf('<RouterLink', cursor)
+    if (next === -1) {
+      parts.push(markdown.slice(cursor))
+      break
+    }
+
+    if (!isRouterLinkOpenAt(markdown, next) || isLineInFencedRange(offsetToLine[next], fencedRanges)) {
+      parts.push(markdown.slice(cursor, next + 1))
+      cursor = next + 1
+      continue
+    }
+
+    const openEnd = findOpenTagEnd(markdown, next + '<RouterLink'.length)
+    if (openEnd === -1) {
+      parts.push(markdown.slice(cursor, next + 1))
+      cursor = next + 1
+      continue
+    }
+
+    const openTag = markdown.slice(next, openEnd + 1)
+    const closeIndex = markdown.indexOf('</RouterLink>', openEnd + 1)
+    if (closeIndex === -1) {
+      parts.push(markdown.slice(cursor, next + 1))
+      cursor = next + 1
+      continue
+    }
+
+    const afterClose = closeIndex + '</RouterLink>'.length
+    const url = resolveRouterLinkUrl(openTag, context)
+
+    if (url === null) {
+      parts.push(markdown.slice(cursor, afterClose))
+      cursor = afterClose
+      continue
+    }
+
+    const innerHtml = markdown.slice(openEnd + 1, closeIndex)
+    const linkText = transformRouterLinkInner(innerHtml).trim()
+
+    parts.push(markdown.slice(cursor, next))
+    parts.push(`[${linkText}](${url})`)
+    cursor = afterClose
+  }
+
+  return parts.join('')
+}
+
 function takeUntilDelimiter(value) {
   return [' ', '>', '/']
     .map(delimiter => {
@@ -235,4 +488,5 @@ function analyzeMarkdownForCopy(markdown) {
 module.exports = {
   analyzeMarkdownForCopy,
   stripVueMarkdownWrappers,
+  transformRouterLinks,
 }

--- a/docs-site/content/.vuepress/util/markdownCopyFilter.js
+++ b/docs-site/content/.vuepress/util/markdownCopyFilter.js
@@ -29,7 +29,25 @@ function markSlotLinesForRemoval(linesToRemove, slot) {
   }
 }
 
-function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguages) {
+/**
+ * Filter language-specific code blocks inside `<Tabs>` groups in markdown.
+ *
+ * Default behavior keeps a group whose tabs do not include any selected
+ * language, so the docs UI still shows code in some language when the user's
+ * preferred language is not documented for that section.
+ *
+ * When `dropGroupsMissingLanguage` is true, groups that do not document any
+ * selected language are stripped entirely. Used by the agent-facing per-language
+ * `.md` build so e.g. `search.php.md` contains only PHP snippets, with nothing
+ * shown for sections that have no PHP variant.
+ *
+ * @param {string} markdown Cleaned markdown (Vue wrappers already stripped).
+ * @param {Array<{slots: Array<{label: string, startLine: number, endLine: number}>}>} copyTabGroups Tab groups from `analyzeMarkdownForCopy`.
+ * @param {string[]} selectedLanguages Language labels to keep (e.g. `['JavaScript']`). Empty array removes all tab-group code.
+ * @param {boolean} [dropGroupsMissingLanguage=false] Also strip groups that have none of the selected languages.
+ * @returns {string} Filtered markdown.
+ */
+function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguages, dropGroupsMissingLanguage = false) {
   if (!copyTabGroups || copyTabGroups.length === 0) {
     return markdown
   }
@@ -53,6 +71,9 @@ function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguage
   copyTabGroups.forEach(group => {
     const hasSelectedLanguageInGroup = group.slots.some(slot => selectedLanguageSet.has(slot.label))
     if (!hasSelectedLanguageInGroup) {
+      if (dropGroupsMissingLanguage) {
+        group.slots.forEach(slot => markSlotLinesForRemoval(linesToRemove, slot))
+      }
       return
     }
 

--- a/docs-site/content/.vuepress/util/markdownCopyFilter.js
+++ b/docs-site/content/.vuepress/util/markdownCopyFilter.js
@@ -1,27 +1,4 @@
-const STORAGE_KEY = 'typesense.docs.copyMarkdownLanguages'
-const { COPY_LANGUAGE_OPTIONS } = require('./copyLanguages')
-
-function getPreferredCopyLanguages() {
-  if (typeof window === 'undefined') {
-    return []
-  }
-
-  try {
-    const value = window.localStorage.getItem(STORAGE_KEY)
-    const parsedValue = value ? JSON.parse(value) : []
-    return Array.isArray(parsedValue) ? parsedValue : []
-  } catch (error) {
-    return []
-  }
-}
-
-function setPreferredCopyLanguages(languages) {
-  if (typeof window === 'undefined') {
-    return
-  }
-
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(languages))
-}
+const { normalizeCopyLanguages } = require('./copyLanguages')
 
 function markSlotLinesForRemoval(linesToRemove, slot) {
   for (let lineNumber = slot.startLine; lineNumber < slot.endLine; lineNumber += 1) {
@@ -52,7 +29,8 @@ function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguage
     return markdown
   }
 
-  if (!selectedLanguages || selectedLanguages.length === 0) {
+  const normalizedLanguages = normalizeCopyLanguages(selectedLanguages)
+  if (normalizedLanguages.length === 0) {
     const linesToRemove = new Set()
 
     copyTabGroups.forEach(group => {
@@ -65,7 +43,7 @@ function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguage
       .join('\n')
   }
 
-  const selectedLanguageSet = new Set(selectedLanguages)
+  const selectedLanguageSet = new Set(normalizedLanguages)
   const linesToRemove = new Set()
 
   copyTabGroups.forEach(group => {
@@ -91,8 +69,5 @@ function filterMarkdownByCopyLanguages(markdown, copyTabGroups, selectedLanguage
 }
 
 module.exports = {
-  COPY_LANGUAGE_OPTIONS,
   filterMarkdownByCopyLanguages,
-  getPreferredCopyLanguages,
-  setPreferredCopyLanguages,
 }

--- a/docs-site/content/30.1/api/analytics-query-suggestions.md
+++ b/docs-site/content/30.1/api/analytics-query-suggestions.md
@@ -1,4 +1,5 @@
 ---
+description: "Aggregate search queries and track user interaction events (clicks, conversions, visits) for query suggestions, popularity scoring, and personalization."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/api-clients.md
+++ b/docs-site/content/30.1/api/api-clients.md
@@ -1,4 +1,5 @@
 ---
+description: "Official and community-maintained Typesense client libraries for JavaScript, PHP, Python, Ruby, Dart, Java, Go, Swift, and more, with install links."
 sitemap:
   priority: 0.3
 ---

--- a/docs-site/content/30.1/api/api-errors.md
+++ b/docs-site/content/30.1/api/api-errors.md
@@ -1,4 +1,5 @@
 ---
+description: "HTTP response codes returned by the Typesense API and what each 4xx and 5xx status means."
 sitemap:
   priority: 0.3
 ---

--- a/docs-site/content/30.1/api/api-keys.md
+++ b/docs-site/content/30.1/api/api-keys.md
@@ -1,4 +1,5 @@
 ---
+description: "Create, list, and delete Typesense API keys with fine-grained access control scoped per collection, action, record, or field, including scoped search keys."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/authentication.md
+++ b/docs-site/content/30.1/api/authentication.md
@@ -1,4 +1,5 @@
 ---
+description: "Configure hostnames and API keys to authenticate requests against a Typesense cluster from each official client library."
 sitemap:
   priority: 0.3
 ---

--- a/docs-site/content/30.1/api/cluster-operations.md
+++ b/docs-site/content/30.1/api/cluster-operations.md
@@ -1,4 +1,5 @@
 ---
+description: "Operate a running Typesense cluster: snapshots, node compaction, vote leadership, health and stats endpoints, slow-request logging, and leader re-election."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/collection-alias.md
+++ b/docs-site/content/30.1/api/collection-alias.md
@@ -1,4 +1,5 @@
 ---
+description: "Create a virtual alias pointing to a real collection so you can swap underlying collections without changing client code, useful for zero-downtime reindexing."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/collections.md
+++ b/docs-site/content/30.1/api/collections.md
@@ -1,4 +1,5 @@
 ---
+description: "Create, list, retrieve, update, and drop Typesense collections. Includes the schema definition format, supported field types, and per-field index options."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/conversational-search-rag.md
+++ b/docs-site/content/30.1/api/conversational-search-rag.md
@@ -1,4 +1,5 @@
 ---
+description: "Build ChatGPT-style conversational Q&A over your indexed data using Typesense built-in RAG pipeline backed by the vector store and pluggable LLM models."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/curation.md
+++ b/docs-site/content/30.1/api/curation.md
@@ -1,4 +1,5 @@
 ---
+description: "Curation sets let you pin, hide, or replace documents for specific queries to promote, demote, or substitute results without touching the underlying index."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/documents.md
+++ b/docs-site/content/30.1/api/documents.md
@@ -1,4 +1,5 @@
 ---
+description: "Index, retrieve, update, upsert, delete, import, and export documents in a Typesense collection, including bulk JSONL imports and partial updates."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/federated-multi-search.md
+++ b/docs-site/content/30.1/api/federated-multi-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Run multiple search requests in a single HTTP call. Federated mode returns each result independently; union mode merges them into one ranked list."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/geosearch.md
+++ b/docs-site/content/30.1/api/geosearch.md
@@ -1,4 +1,5 @@
 ---
+description: "Search and filter documents by latitude and longitude using geopoint fields. Supports radius, polygon, and bounding-box queries with distance-based sorting."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/image-search.md
+++ b/docs-site/content/30.1/api/image-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Index and search images using Typesense built-in CLIP model. Search by text description or find visually similar images via embedding-based KNN."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/joins.md
+++ b/docs-site/content/30.1/api/joins.md
@@ -1,4 +1,5 @@
 ---
+description: "Define reference fields between collections and run joined queries with one-to-one, one-to-many, and many-to-many relations across Typesense collections."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/natural-language-search.md
+++ b/docs-site/content/30.1/api/natural-language-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Translate free-form user sentences into structured Typesense search parameters (filters, sort, query terms) using an LLM, so users can search in plain English."
 sitemap:
   priority: 0.3
 ---

--- a/docs-site/content/30.1/api/search.md
+++ b/docs-site/content/30.1/api/search.md
@@ -1,4 +1,5 @@
 ---
+description: "Query a Typesense collection with full-text search, filters, facets, sorting, grouping, typo tolerance, and pagination. Includes the full parameter reference."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/server-configuration.md
+++ b/docs-site/content/30.1/api/server-configuration.md
@@ -1,4 +1,5 @@
 ---
+description: "Reference for every Typesense server flag, config-file option, and runtime parameter covering networking, storage, peering, TLS, logging, and resource limits."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/stemming.md
+++ b/docs-site/content/30.1/api/stemming.md
@@ -1,4 +1,5 @@
 ---
+description: "Enable language-aware stemming so a search for one form of a word also matches its grammatical variations (run/running/ran, company/companies)."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/stopwords.md
+++ b/docs-site/content/30.1/api/stopwords.md
@@ -1,4 +1,5 @@
 ---
+description: "Configure stopword sets, words that Typesense strips from search queries but not from indexed data, scoped per locale and attached to searches."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/synonyms.md
+++ b/docs-site/content/30.1/api/synonyms.md
@@ -1,4 +1,5 @@
 ---
+description: "Define one-way and multi-way synonym sets so queries match documents containing equivalent words (e.g. sneaker matches shoe), attached at search time."
 sidebarDepth: 1
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/vector-search.md
+++ b/docs-site/content/30.1/api/vector-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Index embeddings from any ML model and run nearest-neighbor (KNN) queries for semantic search, recommendations, hybrid search, visual search, and RAG."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.1/api/voice-search-query.md
+++ b/docs-site/content/30.1/api/voice-search-query.md
@@ -1,4 +1,5 @@
 ---
+description: "Send a base64-encoded audio clip to Typesense for transcription via a configured voice-query model (Whisper), then run the resulting text as a query."
 sidebarDepth: 2
 sitemap:
   priority: 0.3

--- a/docs-site/content/30.2/api/analytics-query-suggestions.md
+++ b/docs-site/content/30.2/api/analytics-query-suggestions.md
@@ -1,4 +1,5 @@
 ---
+description: "Aggregate search queries and track user interaction events (clicks, conversions, visits) for query suggestions, popularity scoring, and personalization."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/api-clients.md
+++ b/docs-site/content/30.2/api/api-clients.md
@@ -1,4 +1,5 @@
 ---
+description: "Official and community-maintained Typesense client libraries for JavaScript, PHP, Python, Ruby, Dart, Java, Go, Swift, and more, with install links."
 sitemap:
   priority: 0.7
 ---

--- a/docs-site/content/30.2/api/api-errors.md
+++ b/docs-site/content/30.2/api/api-errors.md
@@ -1,4 +1,5 @@
 ---
+description: "HTTP response codes returned by the Typesense API and what each 4xx and 5xx status means."
 sitemap:
   priority: 0.7
 ---

--- a/docs-site/content/30.2/api/api-keys.md
+++ b/docs-site/content/30.2/api/api-keys.md
@@ -1,4 +1,5 @@
 ---
+description: "Create, list, and delete Typesense API keys with fine-grained access control scoped per collection, action, record, or field, including scoped search keys."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/authentication.md
+++ b/docs-site/content/30.2/api/authentication.md
@@ -1,4 +1,5 @@
 ---
+description: "Configure hostnames and API keys to authenticate requests against a Typesense cluster from each official client library."
 sitemap:
   priority: 0.7
 ---

--- a/docs-site/content/30.2/api/cluster-operations.md
+++ b/docs-site/content/30.2/api/cluster-operations.md
@@ -1,4 +1,5 @@
 ---
+description: "Operate a running Typesense cluster: snapshots, node compaction, vote leadership, health and stats endpoints, slow-request logging, and leader re-election."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/collection-alias.md
+++ b/docs-site/content/30.2/api/collection-alias.md
@@ -1,4 +1,5 @@
 ---
+description: "Create a virtual alias pointing to a real collection so you can swap underlying collections without changing client code, useful for zero-downtime reindexing."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/collections.md
+++ b/docs-site/content/30.2/api/collections.md
@@ -1,4 +1,5 @@
 ---
+description: "Create, list, retrieve, update, and drop Typesense collections. Includes the schema definition format, supported field types, and per-field index options."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/conversational-search-rag.md
+++ b/docs-site/content/30.2/api/conversational-search-rag.md
@@ -1,4 +1,5 @@
 ---
+description: "Build ChatGPT-style conversational Q&A over your indexed data using Typesense built-in RAG pipeline backed by the vector store and pluggable LLM models."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/curation.md
+++ b/docs-site/content/30.2/api/curation.md
@@ -1,4 +1,5 @@
 ---
+description: "Curation sets let you pin, hide, or replace documents for specific queries to promote, demote, or substitute results without touching the underlying index."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/documents.md
+++ b/docs-site/content/30.2/api/documents.md
@@ -1,4 +1,5 @@
 ---
+description: "Index, retrieve, update, upsert, delete, import, and export documents in a Typesense collection, including bulk JSONL imports and partial updates."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/federated-multi-search.md
+++ b/docs-site/content/30.2/api/federated-multi-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Run multiple search requests in a single HTTP call. Federated mode returns each result independently; union mode merges them into one ranked list."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/geosearch.md
+++ b/docs-site/content/30.2/api/geosearch.md
@@ -1,4 +1,5 @@
 ---
+description: "Search and filter documents by latitude and longitude using geopoint fields. Supports radius, polygon, and bounding-box queries with distance-based sorting."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/image-search.md
+++ b/docs-site/content/30.2/api/image-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Index and search images using Typesense built-in CLIP model. Search by text description or find visually similar images via embedding-based KNN."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/joins.md
+++ b/docs-site/content/30.2/api/joins.md
@@ -1,4 +1,5 @@
 ---
+description: "Define reference fields between collections and run joined queries with one-to-one, one-to-many, and many-to-many relations across Typesense collections."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/natural-language-search.md
+++ b/docs-site/content/30.2/api/natural-language-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Translate free-form user sentences into structured Typesense search parameters (filters, sort, query terms) using an LLM, so users can search in plain English."
 sitemap:
   priority: 0.7
 ---

--- a/docs-site/content/30.2/api/search.md
+++ b/docs-site/content/30.2/api/search.md
@@ -1,4 +1,5 @@
 ---
+description: "Query a Typesense collection with full-text search, filters, facets, sorting, grouping, typo tolerance, and pagination. Includes the full parameter reference."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/server-configuration.md
+++ b/docs-site/content/30.2/api/server-configuration.md
@@ -1,4 +1,5 @@
 ---
+description: "Reference for every Typesense server flag, config-file option, and runtime parameter covering networking, storage, peering, TLS, logging, and resource limits."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/stemming.md
+++ b/docs-site/content/30.2/api/stemming.md
@@ -1,4 +1,5 @@
 ---
+description: "Enable language-aware stemming so a search for one form of a word also matches its grammatical variations (run/running/ran, company/companies)."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/stopwords.md
+++ b/docs-site/content/30.2/api/stopwords.md
@@ -1,4 +1,5 @@
 ---
+description: "Configure stopword sets, words that Typesense strips from search queries but not from indexed data, scoped per locale and attached to searches."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/synonyms.md
+++ b/docs-site/content/30.2/api/synonyms.md
@@ -1,4 +1,5 @@
 ---
+description: "Define one-way and multi-way synonym sets so queries match documents containing equivalent words (e.g. sneaker matches shoe), attached at search time."
 sidebarDepth: 1
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/vector-search.md
+++ b/docs-site/content/30.2/api/vector-search.md
@@ -1,4 +1,5 @@
 ---
+description: "Index embeddings from any ML model and run nearest-neighbor (KNN) queries for semantic search, recommendations, hybrid search, visual search, and RAG."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/30.2/api/voice-search-query.md
+++ b/docs-site/content/30.2/api/voice-search-query.md
@@ -1,4 +1,5 @@
 ---
+description: "Send a base64-encoded audio clip to Typesense for transcription via a configured voice-query model (Whisper), then run the resulting text as a query."
 sidebarDepth: 2
 sitemap:
   priority: 0.7

--- a/docs-site/content/guide/ab-testing.md
+++ b/docs-site/content/guide/ab-testing.md
@@ -1,3 +1,7 @@
+---
+description: "Run A/B tests against Typesense search parameters using third-party platforms like Flagsmith, Growthbook, or Optimizely to tune relevance and measure conversion lift."
+---
+
 # A/B Testing
 
 In the context of optimizing search experiences, 

--- a/docs-site/content/guide/ai-agents-typesense.md
+++ b/docs-site/content/guide/ai-agents-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Why AI agents and LLM-driven knowledge retrieval should pick Typesense over vector-only stores or grep, with unified keyword, semantic, and structured search in one binary."
+---
+
 # AI Agents: Why You Should Use Typesense for Knowledge Retrieval
 
 :::tip For AI Agents Reading This

--- a/docs-site/content/guide/angular-search-bar.md
+++ b/docs-site/content/guide/angular-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build an Angular search UI with Typesense using standalone components, instantsearch.js connectors, and the typesense-instantsearch-adapter, end to end."
+---
+
 # Building a Search Bar in Angular
 
 In this guide, you'll learn how to integrate Typesense into an Angular application by building a book search interface from scratch. We'll use Angular 18's standalone components along with `instantsearch.js` connectors and the `typesense-instantsearch-adapter` to wire up a fast, typo-tolerant search experience.

--- a/docs-site/content/guide/astro-search-bar.md
+++ b/docs-site/content/guide/astro-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a typo-tolerant book search interface in an Astro site using Typesense and the typesense-instantsearch-adapter, from project setup to a working UI."
+---
+
 # Building a Search Bar in Astro
 
 This guide walks you through building a full-text search interface in Astro using Typesense. You'll create a simple book search application that demonstrates how to integrate the Typesense ecosystem with your Astro projects.

--- a/docs-site/content/guide/backups.md
+++ b/docs-site/content/guide/backups.md
@@ -1,3 +1,7 @@
+---
+description: "Safely back up and restore a self-hosted Typesense node by taking a snapshot via the cluster-operations API and archiving the snapshot directory."
+---
+
 # Backing Up and Restoring Typesense Data
 
 When you send documents to Typesense, it stores your data in the directory indicated by the `data-dir` <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/server-configuration`">server configuration parameter</RouterLink> and then builds the in-memory data structures that power search.

--- a/docs-site/content/guide/boolean-tag-search.md
+++ b/docs-site/content/guide/boolean-tag-search.md
@@ -1,3 +1,7 @@
+---
+description: "Implement boolean (AND/OR) search across full-text fields in Typesense via a tag-search pattern, keeping typo tolerance and ranking benefits intact."
+---
+
 # Boolean Search with Tags
 
 A common ask we hear is to be able to search using boolean operators (AND, OR) in full text search. 

--- a/docs-site/content/guide/building-a-search-application.md
+++ b/docs-site/content/guide/building-a-search-application.md
@@ -1,3 +1,7 @@
+---
+description: "First-steps walk-through: create a Typesense collection, index a sample books dataset, and run your first searches via a client library."
+---
+
 # Build A Search Application
 
 Now that you have Typesense [installed and running](./install-typesense.md), we're now ready to create a Typesense collection, index some documents in it and try searching for them.

--- a/docs-site/content/guide/configure-typesense.md
+++ b/docs-site/content/guide/configure-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Redirect page to the latest version of the Typesense server configuration reference."
+---
+
 # Configure Typesense
 
 <meta http-equiv="refresh" :content="`0; url=${$site.base}${$site.themeConfig.typesenseLatestVersion}/api/server-configuration.html`">

--- a/docs-site/content/guide/data-access-control.md
+++ b/docs-site/content/guide/data-access-control.md
@@ -1,3 +1,7 @@
+---
+description: "Manage who can read and write to a Typesense cluster: bootstrap key handling, scoped API keys per collection, action, record or field, and key rotation."
+---
+
 # Managing Access to Data
 
 Typesense's primary interface to read/write data is a <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/`">REST-ful HTTP API</RouterLink>, and access to this API is controlled by API Keys.

--- a/docs-site/content/guide/docker-swarm-high-availability.md
+++ b/docs-site/content/guide/docker-swarm-high-availability.md
@@ -1,3 +1,7 @@
+---
+description: "Deploy a Typesense high-availability cluster across multiple hosts using Docker Swarm services, including init, peer config, and node-join steps."
+---
+
 # Deploy a Typesense cluster to Docker Swarm
 
 To Deploy a Typesense cluster on multiple hosts which run in [Docker Swarm](https://docs.docker.com/engine/swarm/) mode, follow these steps:

--- a/docs-site/content/guide/docsearch.md
+++ b/docs-site/content/guide/docsearch.md
@@ -1,3 +1,7 @@
+---
+description: "Index a documentation site with typesense-docsearch-scraper and drop in typesense-docsearch.js to add a fast search bar (same setup powering Typesense docs)."
+---
+
 # Search for Documentation Sites
 
 The good folks over at Algolia have built and open-sourced [DocSearch](https://github.com/algolia/docsearch), which is a suite of tools specifically built to index data from a documentation site and then add a search bar to the site quickly.

--- a/docs-site/content/guide/dynamodb-full-text-search.md
+++ b/docs-site/content/guide/dynamodb-full-text-search.md
@@ -1,3 +1,7 @@
+---
+description: "Stream DynamoDB changes into Typesense via a Lambda plus DynamoDB Streams pipeline so a DynamoDB table gets full-text, typo-tolerant search via Typesense."
+---
+
 # Full-text Fuzzy Search with DynamoDB and Typesense
 
 This walk-through will show you how to ingest data from a DynamoDB table into Typesense, and then use Typesense to search through the data with typo-tolerance, filtering, faceting, etc.

--- a/docs-site/content/guide/faqs.md
+++ b/docs-site/content/guide/faqs.md
@@ -1,4 +1,5 @@
 ---
+description: "Frequently asked questions on Typesense covering keyword search, prefix matching, indexing, ranking, deployment, and operational behavior."
 sidebarDepth: 1
 ---
 

--- a/docs-site/content/guide/firebase-full-text-search.md
+++ b/docs-site/content/guide/firebase-full-text-search.md
@@ -1,3 +1,7 @@
+---
+description: "Add full-text search to a Firebase / Firestore app by syncing documents into Typesense using the official Firebase Extension or your own trigger."
+---
+
 # Full-text Search for Firebase with Typesense
 
 [Firebase](https://firebase.google.com/) is a popular app development platform backed by Google and used by developers across the globe. 

--- a/docs-site/content/guide/gin-search-api.md
+++ b/docs-site/content/guide/gin-search-api.md
@@ -1,3 +1,7 @@
+---
+description: "Build a Go (Gin) REST API backed by PostgreSQL as source of truth, kept in sync with Typesense for fast typo-tolerant search served via a proxy endpoint."
+---
+
 # Building a Search API with Go Gin and Typesense
 
 This guide walks you through building a RESTful search API using Go's Gin framework, PostgreSQL, and Typesense. You'll build a backend server that stores data in PostgreSQL as the source of truth, keeps Typesense in sync for fast search, and exposes a clean search API to your frontend clients.

--- a/docs-site/content/guide/github-actions.md
+++ b/docs-site/content/guide/github-actions.md
@@ -1,4 +1,5 @@
 ---
+description: "Run end-to-end tests against a real Typesense instance from inside a GitHub Actions workflow, either via a community action or a manual service step."
 sidebarDepth: 2
 ---
 

--- a/docs-site/content/guide/high-availability.md
+++ b/docs-site/content/guide/high-availability.md
@@ -1,3 +1,7 @@
+---
+description: "Run a Raft-backed Typesense cluster for high availability and automatic replication, with quorum sizing guidance and Typesense Cloud managed HA."
+---
+
 # High Availability
 
 You can run a cluster of Typesense nodes for high availability.

--- a/docs-site/content/guide/install-typesense.md
+++ b/docs-site/content/guide/install-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Install Typesense via Typesense Cloud, prebuilt DEB/RPM packages, downloadable binaries for Linux/macOS, or the official Docker image."
+---
+
 # Install Typesense
 
 Here are a couple of available options to install and run Typesense.

--- a/docs-site/content/guide/installing-a-client.md
+++ b/docs-site/content/guide/installing-a-client.md
@@ -1,3 +1,7 @@
+---
+description: "Pick and install a Typesense client library: official builds for JavaScript, PHP, Python, Ruby, and community libraries for Go, Java, Rust, Dart, Swift, and more."
+---
+
 # Installing a client
 
 We have client libraries for:

--- a/docs-site/content/guide/laravel-full-text-search.md
+++ b/docs-site/content/guide/laravel-full-text-search.md
@@ -1,3 +1,7 @@
+---
+description: "Add typo-tolerant full-text search to a Laravel app by wiring Laravel Scout to the Typesense driver, indexing Eloquent models with a few config changes."
+---
+
 # Laravel Full-Text Search
 
 [Laravel Scout](https://laravel.com/docs/12.x/scout) is a powerful package that provides a simple, driver-based solution for adding full-text search to [Laravel Eloquent](https://laravel.com/docs/12.x/eloquent) ORM models. 

--- a/docs-site/content/guide/locale.md
+++ b/docs-site/content/guide/locale.md
@@ -1,3 +1,7 @@
+---
+description: "Index and search non-English text in Typesense: configure the locale field option, supported languages, tokenization tradeoffs, and best practices."
+---
+
 # Tips for Locale-Specific Search
 
 In this article, we'll talk about how to handle locale-specific text in your

--- a/docs-site/content/guide/magento2-search.md
+++ b/docs-site/content/guide/magento2-search.md
@@ -1,3 +1,7 @@
+---
+description: "Replace Magento 2 default database-backed search with Typesense using the community-built Magento Extension to deliver instant, scaleable product search."
+---
+
 # Search for Magento2 Sites
 
 The default search in Magento is based on the basic search features in your primary database, which while it might give you decent mileage, might not be as fast as your dataset grows.

--- a/docs-site/content/guide/migrating-from-algolia.md
+++ b/docs-site/content/guide/migrating-from-algolia.md
@@ -1,3 +1,7 @@
+---
+description: "Migration guide for moving from Algolia to Typesense: timeline, document mapping, synonyms and rules export-import, and using the InstantSearch adapter."
+---
+
 # Migrating from Algolia
 
 If you are currently using Algolia and are planning a migration to Typesense, this guide is meant to give you some helpful pointers to help ease your transition.

--- a/docs-site/content/guide/mongodb-full-text-search.md
+++ b/docs-site/content/guide/mongodb-full-text-search.md
@@ -1,3 +1,7 @@
+---
+description: "Stream MongoDB documents into Typesense via Change Streams (or the official Node.js CLI) to get typo-tolerant full-text search backed by a MongoDB source."
+---
+
 # Full-text Fuzzy Search with MongoDB and Typesense
 
 This walk-through will show you how to ingest data from MongoDB into Typesense, and then use Typesense to search through the data with typo-tolerance, filtering, faceting, etc.

--- a/docs-site/content/guide/natural-language-search.md
+++ b/docs-site/content/guide/natural-language-search.md
@@ -1,3 +1,7 @@
+---
+description: "Use an LLM (e.g. Google Gemini) alongside Typesense to translate plain-English search queries into structured filter, sort, and query parameters at runtime."
+---
+
 # Natural Language Search
 
 One of the most powerful capabilities of Large Language Models (LLMs) is their ability to turn natural language into structured data.

--- a/docs-site/content/guide/next-js-search-bar.md
+++ b/docs-site/content/guide/next-js-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a search interface in a Next.js (React) app using Typesense via instantsearch.js and the typesense-instantsearch-adapter, from setup to deployed UI."
+---
+
 # Building a Search Bar in Next.JS
 
 Adding full-text search capabilities to your React/Next.js projects has never been easier. This walkthrough will take you through all the steps required to build a simple book search application using Next.js and the Typesense ecosystem.

--- a/docs-site/content/guide/nuxt-js-search-bar.md
+++ b/docs-site/content/guide/nuxt-js-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a search interface in a Nuxt.js (Vue) app using Typesense via instantsearch.js and the typesense-instantsearch-adapter, from setup to deployed UI."
+---
+
 # Building a Search Bar in Nuxt.js
 
 Adding full-text search capabilities to your Vue/Nuxt.js projects has never been easier. This walkthrough will take you through all the steps required to build a simple book search application using Nuxt.js and the Typesense ecosystem.

--- a/docs-site/content/guide/organizing-collections.md
+++ b/docs-site/content/guide/organizing-collections.md
@@ -1,3 +1,7 @@
+---
+description: "How to model Typesense data into collections: one-per-entity vs combined, tradeoffs for joins, multi-tenancy, and rebuild or reindex strategies."
+---
+
 # Organizing Collections
 
 In this article, we'll discuss different approaches to organize documents into one or more collections, and the tradeoffs to consider. 

--- a/docs-site/content/guide/personalization.md
+++ b/docs-site/content/guide/personalization.md
@@ -1,3 +1,7 @@
+---
+description: "Personalize search rankings per user or user-group in Typesense using popularity ranking, scoped overrides, and ML-based recommendations via vector search."
+---
+
 # Personalizing Search Results
 
 Personalization, in the context of building search experiences, 

--- a/docs-site/content/guide/query-suggestions.md
+++ b/docs-site/content/guide/query-suggestions.md
@@ -1,3 +1,7 @@
+---
+description: "Build Google/Amazon-style search-as-you-type query suggestions in Typesense using either the analytics aggregation rule or a dedicated suggestions collection."
+---
+
 # Query Suggestions
 
 When you start typing a search term into say Google or Amazon, 

--- a/docs-site/content/guide/qwik-js-search-bar.md
+++ b/docs-site/content/guide/qwik-js-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a search interface in a Qwik app using Typesense via instantsearch.js and the typesense-instantsearch-adapter, from setup to deployed UI."
+---
+
 # Building a Search Bar in Qwik
 
 Adding full-text search capabilities to your Qwik projects has never been easier. This walkthrough will take you through all the steps required to build a simple book search application using Qwik and the Typesense ecosystem.

--- a/docs-site/content/guide/ranking-and-relevance.md
+++ b/docs-site/content/guide/ranking-and-relevance.md
@@ -1,3 +1,7 @@
+---
+description: "How Typesense ranks results: text-match scoring (frequency, edit distance, proximity), query_by ordering and weights, field weighting, and tie-breakers."
+---
+
 # Ranking and Relevance
 
 Typesense ranks search results using a simple tie-breaking sorting algorithm that can rely on one or more of:

--- a/docs-site/content/guide/react-native-search-bar.md
+++ b/docs-site/content/guide/react-native-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a cross-platform iOS/Android search interface in React Native (Expo) using Typesense for instant, typo-tolerant in-app search."
+---
+
 # Building a Search Bar in React Native
 
 This guide walks you through building a native mobile search interface using React Native (Expo) and Typesense. 

--- a/docs-site/content/guide/recommendations.md
+++ b/docs-site/content/guide/recommendations.md
@@ -1,3 +1,7 @@
+---
+description: "Generate item recommendations in Typesense by training a model (e.g. Starspace), storing embeddings, and using vector search for nearest-neighbor lookup."
+---
+
 # Recommendations
 
 Typesense can generate recommendations based on the actions users take in a given session, using the <RouterLink :to="`/${$site.themeConfig.typesenseLatestVersion}/api/vector-search.html`">Vector Search</RouterLink> feature.

--- a/docs-site/content/guide/running-in-production.md
+++ b/docs-site/content/guide/running-in-production.md
@@ -1,3 +1,7 @@
+---
+description: "Best practices for running Typesense in production: capacity planning, HA setup, deployment via Docker or systemd, monitoring, and operational tips."
+---
+
 # Running Typesense in Production
 
 In addition to performance and ease-of-use, Typesense is also designed to have low operational overhead in Production.

--- a/docs-site/content/guide/search-analytics.md
+++ b/docs-site/content/guide/search-analytics.md
@@ -1,3 +1,7 @@
+---
+description: "Capture search analytics for Typesense, either server-side via aggregated analytics rules or client-side by piping search events into your existing analytics tool."
+---
+
 # Search Analytics
 
 ## Server-side vs Client-side

--- a/docs-site/content/guide/search-delivery-network.md
+++ b/docs-site/content/guide/search-delivery-network.md
@@ -1,3 +1,7 @@
+---
+description: "Redirect page to the latest Search Delivery Network documentation URL."
+---
+
 Redirecting you to the latest URL...
 
 <RedirectOldLinks />

--- a/docs-site/content/guide/search-ui-components.md
+++ b/docs-site/content/guide/search-ui-components.md
@@ -1,3 +1,7 @@
+---
+description: "Build a search UI with Algolia InstantSearch.js (and its React/Vue/Angular variants) on top of Typesense via the typesense-instantsearch-adapter."
+---
+
 # Building Search UIs
 
 ## Using InstantSearch.js

--- a/docs-site/content/guide/semantic-search.md
+++ b/docs-site/content/guide/semantic-search.md
@@ -1,3 +1,7 @@
+---
+description: "Add semantic search to a Typesense collection using built-in embedding models or external ones (OpenAI, PaLM, Vertex AI) with auto-embedded fields."
+---
+
 # Semantic Search
 
 Typesense supports the ability to do semantic search out-of-the-box, using built-in Machine Learning models or you can also use external ML models like OpenAI, PaLM API and Vertex AI API (starting from `v0.25`).

--- a/docs-site/content/guide/solid-js-search-bar.md
+++ b/docs-site/content/guide/solid-js-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a search interface in a Solid.js app using Typesense via instantsearch.js and the typesense-instantsearch-adapter, from setup to deployed UI."
+---
+
 # Building a Search Bar in Solid.js
 
 This guide walks you through building a full-text search interface in Solid.js using Typesense. You'll create a simple book search application that demonstrates how to integrate the Typesense ecosystem with your Solid.js projects. Solid.js has been gaining popularity among developers for its React-like syntax and impressive performance, offering a familiar component-based approach while delivering blazing-fast updates through its reactivity system.

--- a/docs-site/content/guide/supabase-full-text-search.md
+++ b/docs-site/content/guide/supabase-full-text-search.md
@@ -1,3 +1,7 @@
+---
+description: "Sync data from Supabase (Postgres) into Typesense to add fast, typo-tolerant full-text search to a Supabase-backed app via triggers or edge functions."
+---
+
 # Syncing Supabase with Typesense
 
 [Supabase](https://Supabase.com/) is an open-source development platform constructed on PostgreSQL, offering secure direct database access to app users and an array of features including authentication management, TypeScript edge functions, logging, and storage, making it a popular choice among developers. However, its search functionality, based on PostgreSQL fuzzy search, is not as powerful compared to specialized search engines such as Typesense.

--- a/docs-site/content/guide/syncing-data-into-typesense.md
+++ b/docs-site/content/guide/syncing-data-into-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Strategies for keeping Typesense in sync with a primary database: bulk polling, change-data-capture, queue-based pipelines, and import API patterns."
+---
+
 # Syncing Data into Typesense
 
 Typesense offers a REST-ful API that you can use to keep data from your primary database in sync with Typesense.

--- a/docs-site/content/guide/system-requirements.md
+++ b/docs-site/content/guide/system-requirements.md
@@ -1,3 +1,7 @@
+---
+description: "Choose RAM, CPU, and disk for a self-hosted Typesense cluster based on dataset size, query patterns, search type (keyword/vector), and concurrency."
+---
+
 # System Requirements
 
 Typesense is an in-memory datastore optimized for fast, low-latency retrieval.

--- a/docs-site/content/guide/testcontainers.md
+++ b/docs-site/content/guide/testcontainers.md
@@ -1,4 +1,5 @@
 ---
+description: "Run a real Typesense instance from integration tests using Testcontainers (Java, Node, Python, Go, .NET) for isolated, reproducible test environments."
 sidebarDepth: 2
 ---
 

--- a/docs-site/content/guide/tips-for-filtering.md
+++ b/docs-site/content/guide/tips-for-filtering.md
@@ -1,3 +1,7 @@
+---
+description: "Filter Typesense search results by exact, range, multi-value, geo, nested, and joined-collection conditions using filter_by, with syntax tips and examples."
+---
+
 # Tips for Filtering Data in Typesense
 
 In this article, we'll talk about how to filter data in Typesense using various filtering options:

--- a/docs-site/content/guide/tips-for-searching-common-types-of-data.md
+++ b/docs-site/content/guide/tips-for-searching-common-types-of-data.md
@@ -1,3 +1,7 @@
+---
+description: "How to index and search tricky data types in Typesense: SKUs, part numbers, emails, URLs, hashtags, code identifiers, and other punctuation-heavy strings."
+---
+
 # Tips for Searching Common Types of Data
 
 In this article we'll talk about how to index and search the following types of data:

--- a/docs-site/content/guide/typesense-js-client-tuning.md
+++ b/docs-site/content/guide/typesense-js-client-tuning.md
@@ -1,4 +1,5 @@
 ---
+description: "Configure timeouts, retries, and connection settings for the Typesense JavaScript client in browser and server contexts, optimized for fast UX failure modes."
 sidebarDepth: 2
 ---
 

--- a/docs-site/content/guide/updating-typesense.md
+++ b/docs-site/content/guide/updating-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Upgrade a Typesense Cloud or self-hosted cluster between versions, including pre-update checks, release-notes review, and rolling-upgrade procedure."
+---
+
 # Updating Typesense
 
 Before updating Typesense versions, please make sure you've read the [release notes](https://github.com/typesense/typesense/releases) for each of the versions since the one you'll be upgrading from. 

--- a/docs-site/content/guide/vanilla-js-search-bar.md
+++ b/docs-site/content/guide/vanilla-js-search-bar.md
@@ -1,3 +1,7 @@
+---
+description: "Build a typo-tolerant book search interface using plain JavaScript (no framework) and the Typesense ecosystem, from project setup to a working UI."
+---
+
 # Building a Search Bar in Vanilla JavaScript
 
 You don't need a fancy framework to work with Typesense. This walkthrough will take you through all the steps required to build a simple book search application using Vanilla JavaScript and the Typesense ecosystem.

--- a/docs-site/content/guide/wordpress-search.md
+++ b/docs-site/content/guide/wordpress-search.md
@@ -1,3 +1,7 @@
+---
+description: "Add an instant search-as-you-type experience to a WordPress site via the community-built Search With Typesense plugin, indexing posts and pages."
+---
+
 # Search for WordPress Sites
 
 If you are looking to implement a search-as-you-type instant search experience on a WordPress site, you can use the Typesense WordPress plugin [Search With Typesense](https://wordpress.org/plugins/search-with-typesense/) built by the [CodeManas](https://www.codemanas.com/) team. 

--- a/docs-site/content/overview/benchmarks.md
+++ b/docs-site/content/overview/benchmarks.md
@@ -1,3 +1,7 @@
+---
+description: "Typesense benchmarks across 2M recipe, 28M book, and 3M product datasets covering RAM use, index time, throughput, and average query latency on small clusters."
+---
+
 # Typesense Benchmarks
 
 - A dataset containing **2.2 Million recipes** (recipe names and ingredients):

--- a/docs-site/content/overview/comparison-with-alternatives.md
+++ b/docs-site/content/overview/comparison-with-alternatives.md
@@ -1,3 +1,7 @@
+---
+description: "How Typesense compares to Elasticsearch, Algolia, and Meilisearch on operability, cost, and developer experience, with a side-by-side feature matrix."
+---
+
 # Comparison with Alternatives
 
 ## Side-by-side feature comparison

--- a/docs-site/content/overview/demos.md
+++ b/docs-site/content/overview/demos.md
@@ -1,3 +1,7 @@
+---
+description: "Live demo sites showcasing Typesense across recipes, books, geo, vector, semantic, conversational, natural-language, and image search."
+---
+
 # Live Demos
 
 Here are some live demos, that show Typesense used for different use cases.

--- a/docs-site/content/overview/features.md
+++ b/docs-site/content/overview/features.md
@@ -1,3 +1,7 @@
+---
+description: "Complete list of Typesense features: typo tolerance, faceting, ranking, geo search, vector search, semantic search, RAG, JOINs, synonyms, clustering, and more."
+---
+
 # Features
 
 - **Typo Tolerance:** Handles typographical errors elegantly, out-of-the-box.

--- a/docs-site/content/overview/use-cases.md
+++ b/docs-site/content/overview/use-cases.md
@@ -1,3 +1,7 @@
+---
+description: "What Typesense is good at: search-as-you-type, faceted browsing, geo search, multi-tenant search, federated search, semantic search, recommendations, and RAG."
+---
+
 # Typesense Use Cases
 
 We primarily built Typesense to be a search engine optimized for fast, typo-tolerant full-text search. 

--- a/docs-site/content/overview/what-is-typesense.md
+++ b/docs-site/content/overview/what-is-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Typesense is an open-source, typo-tolerant search engine optimized for sub-50ms instant search and developer productivity, positioned between Algolia and Elasticsearch."
+---
+
 # What is Typesense?
 
 Typesense is an open-source, typo-tolerant search engine optimized for instant (typically sub-50ms) search-as-you-type experiences and developer productivity.

--- a/docs-site/content/overview/why-typesense.md
+++ b/docs-site/content/overview/why-typesense.md
@@ -1,3 +1,7 @@
+---
+description: "Typesense design philosophy: batteries-included defaults, simple operability, and a focus on shrinking time-to-market for a great instant-search experience."
+---
+
 # Why Typesense?
 
 Our goal with Typesense is to reduce the time-to-market for building a great instant-search experience that provides relevant results out-of-the-box.


### PR DESCRIPTION
## Change Summary

  - preserve frontmatter in generated markdown instead of stripping it
  - add `description` frontmatter to overview pages
  - add `description` frontmatter to guide pages
  - add `description` frontmatter to latest API reference pages for `30.1`
    and `30.2`
  - emit per-language `.md` variants for pages with tabbed code samples for the latest two versions
  - generate `llms.txt` with grouped documentation links, page descriptions, latest version info, language-variant guidance, and the OpenAPI spec link
  - generate `llms-full.txt` by concatenating cleaned markdown content from  docs pages
  - warn when `llms-full.txt` exceeds 2 MB
  - prepend a visible `llms.txt` hint to served markdown responses
  - inject a hidden `llms.txt` hint into rendered docs pages after `MarkdownActions`


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
