### PR TITLE
Add Terminal UI link for Typesense administration

### DIFF
--- a/docs-site/content/30.2/api/api-clients.md
+++ b/docs-site/content/30.2/api/api-clients.md
@@ -214,6 +214,7 @@ We also have the following framework integrations:
 - [Enterspeed ETL](https://docs.enterspeed.com/integrations/typesense)
 - [Sitemap Generator from Typesense Data](https://github.com/adviise/typesense-sitemap)
 - [typesense-cli](https://github.com/AlexBV117/typesense-cli)
+- [Terminal UI for administering Typesense](https://github.com/ekrist1/typesensecli)
 - [Prometheus Exporter](https://github.com/imatefx/typesense-prometheus-exporter)
 
 :::tip


### PR DESCRIPTION
clisense gives you a tabbed, full-screen TUI to browse and manage the building blocks of a Typesense deployment without juggling curl commands: collections, aliases, natural-language search models, curations, synonyms, stopwords, presets, and conversation models. Each resource has an embedded JSON editor seeded from sensible templates, plus guided wizards for the trickier ones.

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
