### PR TITLE
docs(synonyms): Update locale-specific synonyms explanation

### DIFF
--- a/docs-site/content/30.2/api/synonyms.md
+++ b/docs-site/content/30.2/api/synonyms.md
@@ -27,7 +27,7 @@ When using Synonym Sets and [Overrides](./curation.md) together, Overrides are h
 :::
 
 :::tip Locale-specific synonyms
-When a synonym has a `locale` specified, it will only be applied when searching fields with a matching locale. If no locale is specified for a synonym, it will be applied globally. This helps manage cases where the same word has different meanings across languages.
+When a synonym has a `locale` specified, it will only be applied when the most weighted searched field has a matching locale. If no locale is specified for a synonym, it will be applied globally. This helps manage cases where the same word has different meanings across languages.
 :::
 
 :::tip Phrase Match Queries & Filtering


### PR DESCRIPTION
## Change Summary
Clarify that locale-specific synonyms in search are matched against the most weighted searched field, irrespective of the locale of other searched fields, as per this comment in [Synonym handling per language #2006](https://github.com/typesense/typesense/issues/2006#issuecomment-2454677051).

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
