### PR TITLE
Stemming: clarify that stem_dictionary disables Snowball fallback

### DIFF
--- a/docs-site/content/29.1/api/stemming.md
+++ b/docs-site/content/29.1/api/stemming.md
@@ -120,7 +120,7 @@ When configuring a field for stemming:
 
 1. Using `"stem": true` alone applies the default Porter stemmer algorithm
 1. Using `"stem_dictionary": "dictionary_name"` automatically enables stemming functionality (`"stem": true` is implied)
-1. When explicitly configuring both options on the same field, dictionary stemming takes precedence
+1. When explicitly configuring both options on the same field, only dictionary stems will be used. In this case snowball's stemming options should be exported and added to the stemming dictionary manually instead.
 
 When you specify only `stem_dictionary` in your configuration, you'll notice `"stem": true` appears automatically in your schema because the system enables basic stemming by default when dictionary stemming is configured.
 :::

--- a/docs-site/content/30.2/api/stemming.md
+++ b/docs-site/content/30.2/api/stemming.md
@@ -121,7 +121,7 @@ When configuring a field for stemming:
 
 1. Using `"stem": true` alone applies the default Porter stemmer algorithm
 1. Using `"stem_dictionary": "dictionary_name"` automatically enables stemming functionality (`"stem": true` is implied)
-1. When explicitly configuring both options on the same field, dictionary stemming takes precedence
+1. When explicitly configuring both options on the same field, only dictionary stems will be used. In this case snowball's stemming options should be exported and added to the stemming dictionary manually instead.
 
 When you specify only `stem_dictionary` in your configuration, you'll notice `"stem": true` appears automatically in your schema because the system enables basic stemming by default when dictionary stemming is configured.
 :::


### PR DESCRIPTION
When both stem:true and stem_dictionary are set on a field, only the dictionary is used; Snowball does not run as a fallback for words absent from the dictionary. Replace the ambiguous 'takes precedence' wording in the 30.2 and 29.1 stemming docs. Ref typesense/typesense#2978.

## Change Summary

Changing the note: 
"When explicitly configuring both options on the same field, dictionary stemming takes precedence" 
to 
"When explicitly configuring both options on the same field, only dictionary stems will be used. In this case snowball's stemming options should be exported and added to the stemming dictionary manually instead." 

This feels like behavior where the fallback would be the more intuitive behavior, but probably is a low priority feature to add, so for now this seems OK in the docs. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
