### PR TITLE
docs: clarify that `store: false` fields are not persisted after a restart

### DIFF
--- a/docs-site/content/30.2/api/collections.md
+++ b/docs-site/content/30.2/api/collections.md
@@ -449,7 +449,7 @@ string, then the next document that contains the field named `title` will be exp
 | facet         | no       | Enables faceting on the field. Default: `false`.                                                                                           |
 | optional      | no       | When set to `true`, the field can have empty, null or missing values. Default: `false`.                                                    |
 | index         | no       | When set to `false`, the field will not be indexed in **any** in-memory index (e.g. search/sort/filter/facet).  Default: `true`.           |
-| store         | no       | When set to `false`, the field value will not be stored on disk.  Default: `true`.                                                         |
+| store         | no       | When set to `false`, the field value is removed from the document before it is written to disk. Such a field is **not** persisted and will be absent after a restart (see the warning below the table). Default: `true`. |
 | sort          | no       | When set to `true`, the field will be sortable.  Default: `true` for numbers, `false` otherwise.                                           |
 | infix         | no       | When set to `true`, the field value can be infix-searched.  Incurs significant memory overhead. Default: `false`.                          |
 | locale        | no       | For configuring language specific tokenization, e.g. `jp` for Japanese. Default: `en` which also broadly supports most European languages. |
@@ -459,6 +459,14 @@ string, then the next document that contains the field named `title` will be exp
 | range_index   | no       | Enables an index optimized for range filtering on numerical fields (e.g. `rating:>3.5`). Default: `false`.                                 |
 | stem          | no       | Values are stemmed before indexing in-memory. Default: `false`.                                                                            |
 | truncate_len  | no       | Maximum number of characters to index per token for string fields. Default: `100`.                                                         |
+
+:::warning A field with store: false is not persisted
+`store: false` removes the field's value from the document before it is written to disk, so the value only exists in the in-memory index while the server is running. After any full reload of the on-disk data (a restart, snapshot restore, node replacement, or version upgrade), the field is **absent** from the reloaded documents.
+
+Keep this in mind when designing your schema:
+
+- **Don't use `store: false` for data you need to have available after a restart.** For example, if a `float[]` vector field is set to `store: false`, its vectors are not persisted, so vector search on that field returns no results after a restart until you re-index them. If you want vector search to survive restarts, keep the vector field stored (`store: true`, the default).
+:::
 
 ### Field types
 

--- a/docs-site/content/30.2/api/image-search.md
+++ b/docs-site/content/30.2/api/image-search.md
@@ -53,6 +53,10 @@ Notice the new data type called `type: image` for the field named `image`, which
 
 The `store: false` property in the field definition tells Typesense to use the field only for generating the embeddings, and to then discard the image from the document and not store it on disk. 
 
+:::tip
+Because `store: false` discards the image, it is not present after a restart. That is fine here, because the vector it produces is written to the `embedding` field, which is stored by default (`store: true`) and so image search keeps working after a restart. Before setting `store: false` on a field whose value you actually need after a restart, read the [note on `store: false`](./collections.md#schema-parameters) in the Collections reference.
+:::
+
 You can also combine text and image into a single embedding with a collection schema like the following:
 
 ```json{8-12,16-22}


### PR DESCRIPTION
## Change Summary


- rewrite the `store` row in the collections field table to say the value is removed before it is written to disk and is absent after a restart
- add a warning callout below the table explaining `store: false` values live only in-memory and vanish on restart, snapshot restore, node replacement, or upgrade
- caution against `store: false` for data needed after a restart, using a `float[]` vector field losing its vectors as the example
- add a tip to the image-search guide noting the discarded image is fine because its `embedding` field is stored by default, cross-linking the collections note

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
