### PR TITLE
Clarify scoped search key gives access to joined collections

### DIFF
--- a/docs-site/content/28.0/api/api-keys.md
+++ b/docs-site/content/28.0/api/api-keys.md
@@ -250,6 +250,10 @@ curl 'http://localhost:8108/keys' \
 
 By setting the `actions` scope to `["documents:search"]` and the `collections` scope to `["companies"]`, we can generate a key that is allowed to only conduct searches on the `companies` collection.
 
+:::warning
+A search key scoped to a collection also exposes data from any collection that its schema references, when that data is fetched through a [joined query](./joins.md). The key does not allow searching the referenced collection directly.
+:::
+
 #### Sample Response
 
 <Tabs :tabs="['JSON']">

--- a/docs-site/content/28.0/api/joins.md
+++ b/docs-site/content/28.0/api/joins.md
@@ -88,6 +88,10 @@ Fields of type `int32`, `int64`, and `string` can be used in the case of "one-to
 being related to exactly one reference document. Fields of type `int32[]`, `int64[]`, and `string[]` can be used in 
 the case of multiple references, i.e. one document being related to zero or more documents in another collection.
 
+:::warning
+Adding a `reference` field makes the referenced collection reachable through joins. A search key scoped only to this collection can then read the referenced collection's fields via a joined query — though still not search it directly. See [Search-only API Key](./api-keys.md#search-only-api-key).
+:::
+
 ## One-to-many relation
 
 ### Simple Example

--- a/docs-site/content/29.0/api/api-keys.md
+++ b/docs-site/content/29.0/api/api-keys.md
@@ -250,6 +250,10 @@ curl 'http://localhost:8108/keys' \
 
 By setting the `actions` scope to `["documents:search"]` and the `collections` scope to `["companies"]`, we can generate a key that is allowed to only conduct searches on the `companies` collection.
 
+:::warning
+A search key scoped to a collection also exposes data from any collection that its schema references, when that data is fetched through a [joined query](./joins.md). The key does not allow searching the referenced collection directly.
+:::
+
 #### Sample Response
 
 <Tabs :tabs="['JSON']">

--- a/docs-site/content/29.0/api/joins.md
+++ b/docs-site/content/29.0/api/joins.md
@@ -88,6 +88,10 @@ Fields of type `int32`, `int64`, and `string` can be used in the case of "one-to
 being related to exactly one reference document. Fields of type `int32[]`, `int64[]`, and `string[]` can be used in 
 the case of multiple references, i.e. one document being related to zero or more documents in another collection.
 
+:::warning
+Adding a `reference` field makes the referenced collection reachable through joins. A search key scoped only to this collection can then read the referenced collection's fields via a joined query — though still not search it directly. See [Search-only API Key](./api-keys.md#search-only-api-key).
+:::
+
 ## One-to-many relation
 
 ### Simple Example

--- a/docs-site/content/29.1/api/api-keys.md
+++ b/docs-site/content/29.1/api/api-keys.md
@@ -250,6 +250,10 @@ curl 'http://localhost:8108/keys' \
 
 By setting the `actions` scope to `["documents:search"]` and the `collections` scope to `["companies"]`, we can generate a key that is allowed to only conduct searches on the `companies` collection.
 
+:::warning
+A search key scoped to a collection also exposes data from any collection that its schema references, when that data is fetched through a [joined query](./joins.md). The key does not allow searching the referenced collection directly.
+:::
+
 #### Sample Response
 
 <Tabs :tabs="['JSON']">

--- a/docs-site/content/29.1/api/joins.md
+++ b/docs-site/content/29.1/api/joins.md
@@ -88,6 +88,10 @@ Fields of type `int32`, `int64`, and `string` can be used in the case of "one-to
 being related to exactly one reference document. Fields of type `int32[]`, `int64[]`, and `string[]` can be used in 
 the case of multiple references, i.e. one document being related to zero or more documents in another collection.
 
+:::warning
+Adding a `reference` field makes the referenced collection reachable through joins. A search key scoped only to this collection can then read the referenced collection's fields via a joined query — though still not search it directly. See [Search-only API Key](./api-keys.md#search-only-api-key).
+:::
+
 ## One-to-many relation
 
 ### Simple Example

--- a/docs-site/content/30.0/api/api-keys.md
+++ b/docs-site/content/30.0/api/api-keys.md
@@ -250,6 +250,10 @@ curl 'http://localhost:8108/keys' \
 
 By setting the `actions` scope to `["documents:search"]` and the `collections` scope to `["companies"]`, we can generate a key that is allowed to only conduct searches on the `companies` collection.
 
+:::warning
+A search key scoped to a collection also exposes data from any collection that its schema references, when that data is fetched through a [joined query](./joins.md). The key does not allow searching the referenced collection directly.
+:::
+
 #### Sample Response
 
 <Tabs :tabs="['JSON']">

--- a/docs-site/content/30.0/api/joins.md
+++ b/docs-site/content/30.0/api/joins.md
@@ -88,6 +88,10 @@ Fields of type `int32`, `int64`, and `string` can be used in the case of "one-to
 being related to exactly one reference document. Fields of type `int32[]`, `int64[]`, and `string[]` can be used in 
 the case of multiple references, i.e. one document being related to zero or more documents in another collection.
 
+:::warning
+Adding a `reference` field makes the referenced collection reachable through joins. A search key scoped only to this collection can then read the referenced collection's fields via a joined query — though still not search it directly. See [Search-only API Key](./api-keys.md#search-only-api-key).
+:::
+
 ## One-to-many relation
 
 ### Simple Example

--- a/docs-site/content/30.1/api/api-keys.md
+++ b/docs-site/content/30.1/api/api-keys.md
@@ -251,6 +251,10 @@ curl 'http://localhost:8108/keys' \
 
 By setting the `actions` scope to `["documents:search"]` and the `collections` scope to `["companies"]`, we can generate a key that is allowed to only conduct searches on the `companies` collection.
 
+:::warning
+A search key scoped to a collection also exposes data from any collection that its schema references, when that data is fetched through a [joined query](./joins.md). The key does not allow searching the referenced collection directly.
+:::
+
 #### Sample Response
 
 <Tabs :tabs="['JSON']">

--- a/docs-site/content/30.1/api/joins.md
+++ b/docs-site/content/30.1/api/joins.md
@@ -89,6 +89,10 @@ Fields of type `int32`, `int64`, and `string` can be used in the case of "one-to
 being related to exactly one reference document. Fields of type `int32[]`, `int64[]`, and `string[]` can be used in 
 the case of multiple references, i.e. one document being related to zero or more documents in another collection.
 
+:::warning
+Adding a `reference` field makes the referenced collection reachable through joins. A search key scoped only to this collection can then read the referenced collection's fields via a joined query — though still not search it directly. See [Search-only API Key](./api-keys.md#search-only-api-key).
+:::
+
 ## One-to-many relation
 
 ### Simple Example

--- a/docs-site/content/30.2/api/api-keys.md
+++ b/docs-site/content/30.2/api/api-keys.md
@@ -251,6 +251,10 @@ curl 'http://localhost:8108/keys' \
 
 By setting the `actions` scope to `["documents:search"]` and the `collections` scope to `["companies"]`, we can generate a key that is allowed to only conduct searches on the `companies` collection.
 
+:::warning
+A search key scoped to a collection also exposes data from any collection that its schema references, when that data is fetched through a [joined query](./joins.md). The key does not allow searching the referenced collection directly.
+:::
+
 #### Sample Response
 
 <Tabs :tabs="['JSON']">

--- a/docs-site/content/30.2/api/joins.md
+++ b/docs-site/content/30.2/api/joins.md
@@ -89,6 +89,10 @@ Fields of type `int32`, `int64`, and `string` can be used in the case of "one-to
 being related to exactly one reference document. Fields of type `int32[]`, `int64[]`, and `string[]` can be used in 
 the case of multiple references, i.e. one document being related to zero or more documents in another collection.
 
+:::warning
+Adding a `reference` field makes the referenced collection reachable through joins. A search key scoped only to this collection can then read the referenced collection's fields via a joined query — though still not search it directly. See [Search-only API Key](./api-keys.md#search-only-api-key).
+:::
+
 ## One-to-many relation
 
 ### Simple Example


### PR DESCRIPTION

A search key scoped to a collection also exposes fields from collections its schema references, when those are fetched through a joined query. The key still cannot search the referenced collection directly.

Documented from both sides — the Search-only API Key section in api-keys, and the reference-field setup in joins — for v28.0 through v30.2.

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
