### PR TITLE
Update collection schema name from 'companies' to 'books'

### DIFF
--- a/docs-site/content/guide/building-a-search-application.md
+++ b/docs-site/content/guide/building-a-search-application.md
@@ -273,7 +273,7 @@ CollectionResponse collectionResponse = client.collections().create(collectionSc
 
 ```go
 booksSchema := &api.CollectionSchema{
-  Name: "companies",
+  Name: "books",
   Fields: []api.Field{
     {Name: "title", Type: "string"},
     {Name: "authors", Type: "string[]", Facet: pointer.True()},


### PR DESCRIPTION
## Change Summary
Fixed a typo in the Go code example under "Creating a books collection" — 
the collection schema used `Name: "companies"` instead of `Name: "books"`, 
which was inconsistent with the section title and the rest of the fields 
(title, authors, publication_year, etc).

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
